### PR TITLE
Add templates and scripts to deploy Che on OpenShift

### DIFF
--- a/os-templates/README.md
+++ b/os-templates/README.md
@@ -1,0 +1,177 @@
+# How to deploy Che on OpenShift
+Scripts, patchs and templates to run Eclipse Che on OpenShift
+
+## Deploy Che on che.ci.centos.org
+
+1\. [Optional] Build Che (`openshift-connector` branch) 
+
+This step is optional: the Docker image is already built and available on Docker Hub `mariolet/che-server:openshiftconnector`.
+
+Instructions to build the image:
+
+```sh
+# Get the source code 
+git clone https://github.com/l0rd/che.git
+cd che
+git checkout openshift-connector
+
+# Install pre-requisites (CentOS)
+yum -y update
+yum -y install centos-release-scl  java-1.8.0-openjdk-devel  git  patch
+yum -y install rh-maven33 rh-nodejs4
+
+source scl_source enable rh-maven33 rh-nodejs4
+ 
+# Build Che 
+export NPM_CONFIG_PREFIX=~/.node_modules
+export PATH=$NPM_CONFIG_PREFIX/bin:$PATH
+npm install -g bower gulp typings
+mvn clean install -Pfast
+
+# Build docker image and push it to a registry
+docker build -t mariolet/che-server:openshiftconnector .
+docke push mariolet/che-server:openshiftconnector
+```
+
+2\. Configure OpenShift
+
+```sh
+# Create OpenShift project
+oc login -u openshift-dev che.ci.centos.org
+oc new-project eclipse-che
+
+# Create a serviceaccount with privileged scc
+oc login -u system:admin -n eclipse-che
+oc create serviceaccount cheserviceaccount
+oc adm policy add-scc-to-user privileged -z cheserviceaccount
+```
+
+3\. Deploy Che
+
+```sh
+# Get the script from github
+git clone https://github.com/redhat-developer/rh-che
+cd rh-che/scripts
+# Prepare the environment
+oc login -u openshift-dev che.ci.centos.org
+export CHE_HOSTNAME=che.ci.centos.org
+export CHE_IMAGE=mariolet/che-server:openshiftconnector
+export DOCKER0_IP=10.1.0.1
+export CHE_LOG_LEVEL=DEBUG
+# If a previous version of Che was deployed, delete it
+./openche.sh delete
+# Install OpenShift Che templat eand deploy Che 
+./openche.sh deploy
+```
+Once the pod is successfully started Che dashboard should be now available at http://che.ci.centos.org/
+
+
+## Deployment Che on Minishift
+
+1\. Get [minishift](https://github.com/minishift/minishift#installation), create an OpenShift cluster (`minishift start`), open the web console (`minishift console`) and read the instructions to install the OpenShift CLI (help->Command Line Tools).
+
+2\. Use that command to use minishift docker daemon: `eval $(minishift docker-env)`
+
+3\. Configure OpenShift
+
+```sh
+# Enable OpenShift router
+oc login -u admin -p admin -n default
+docker pull openshift/origin-haproxy-router:`oc version | awk '{ print $2; exit }'`
+oc adm policy add-scc-to-user hostnetwork -z router
+oc adm router --create --service-account=router --expose-metrics --subdomain="openshift.mini"
+
+# Create OpenShift project
+oc login -u openshift-dev -p devel
+oc new-project eclipse-che
+
+# Create a serviceaccount with privileged scc
+oc login -u admin -p admin -n eclipse-che
+oc create serviceaccount cheserviceaccount
+oc adm policy add-scc-to-user privileged -z cheserviceaccount
+```
+
+4\. Update `/etc/hosts` with a line that associates minishift IP address (`minishift ip`) and the hostname `che.openshift.mini`
+
+5\. Deploy Che
+
+```sh
+# Get the script from github
+git clone https://github.com/redhat-developer/rh-che
+cd rh-che/scripts
+# Prepare the environment
+oc login -u openshift-dev -p devel
+export CHE_HOSTNAME=che.openshift.mini
+export CHE_IMAGE=mariolet/che-server:openshiftconnector
+export DOCKER0_IP=$(docker run -ti --rm --net=host alpine ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+export CHE_OPENSHIFT_ENDPOINT=https://$(minishift ip):8443
+docker pull $CHE_IMAGE
+# If a previous version of Che was deployed, delete it
+./openche.sh delete
+# Install OpenShift Che templat eand deploy Che 
+./openche.sh deploy
+```
+Once the pod is successfully started Che dashboard should be now available on the minishift console.
+
+## Deployment of Che on ADB (deprecated, use minishift instead)
+
+1\. Get the [atomic developer bundle](https://github.com/projectatomic/adb-atomic-developer-bundle#how-do-i-install-and-run-adb)
+
+2\. Start a shell in ADB VM
+
+```sh
+vagrant ssh
+```
+
+3\. Get docker-latest (v.1.12.1) and disable older docker (v1.10.3)
+
+```sh
+# Stop Docker and OpenShift
+sudo systemctl stop openshift
+sudo systemctl stop docker
+sudo systemctl disable docker
+# Get docker-latest
+sudo yum install -y docker-latest
+# Update OpenShift service config
+sudo sed -i.orig -e "s/^After=.*/After=docker-latest.service/g" /usr/lib/systemd/system/openshift.service
+sudo sed -i.orig -e "s/^Requires=.*/Requires=docker-latest.service/g" /usr/lib/systemd/system/openshift.service
+# Change docker-latest config to use docker-current configuration
+sudo sed -i.orig -e "s/docker-latest/docker/g" /usr/lib/systemd/system/docker-latest.service
+sudo sed -i.orig -e "s/Wants=docker-storage-setup.service/Wants=docker-latest-storage-setup.service/g" /usr/lib/systemd/system/docker-latest.service
+# Restart Docker and OpenShift
+sudo systemctl start docker-latest
+sudo systemctl enable docker-latest
+sudo systemctl start openshift
+```
+
+4\. Configure OpenShift
+
+```sh
+# Create OpenShift project
+oc login -u openshift-dev -p devel
+oc new-project eclipse-che
+
+# Create a serviceaccount with privileged scc
+oc login -u admin -p admin -n eclipse-che
+oc create serviceaccount cheserviceaccount
+oc adm policy add-scc-to-user privileged -z cheserviceaccount
+```
+
+5\. Deploy Che
+
+```sh
+# Get the script from github
+git clone https://github.com/redhat-developer/rh-che/
+cd rh-che
+# Prepare the environment
+oc login -u openshift-dev -p devel
+export CHE_HOSTNAME=che.openshift.adb
+export CHE_IMAGE=codenvy/che-server:5.0.0-latest
+docker pull $CHE_IMAGE
+# If a previous version of Che was deployed, delete it
+./openche.sh delete
+# Install OpenShift Che templat eand deploy Che 
+./openche.sh deploy
+```
+Once the pod is successfully started Che dashboard should be now available at http://che.openshift.adb/
+

--- a/os-templates/che.json
+++ b/os-templates/che.json
@@ -1,0 +1,283 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Application template for Eclipse Che",
+            "iconClass" : "icon-openjdk",
+            "tags" : "eclipse,che,java,angular,ide",
+            "version" : "5.0.0"
+        },
+        "name": "eclipse-che"
+    },
+    "labels": {
+        "template": "eclipse-che",
+        "xpaas" : "5.0.0"
+    },
+    "parameters": [
+        {
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "che-host",
+            "required": true
+        },
+        {
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTP",
+            "value": "che.openshift.local",
+            "required": false
+        },
+        {
+            "description": "Name of the che-server Docker image.",
+            "name": "CHE_SERVER_DOCKER_IMAGE",
+            "value": "codenvy/che-server:5.0.0-latest",
+            "required": true
+        },
+        {
+            "description": "Url of the OpenShift API",
+            "name": "CHE_OPENSHIFT_ENDPOINT",
+            "value": "",
+            "required": true
+        },
+        {
+            "description": "OpenShift username",
+            "name": "CHE_OPENSHIFT_USERNAME",
+            "value": "openshift-dev",
+            "required": true
+        },
+        {
+            "description": "OpenShift userpassword.",
+            "name": "CHE_OPENSHIFT_PASSWORD",
+            "value": "devel",
+            "required": true
+        },
+        {
+            "description": "OpenShift project.",
+            "name": "CHE_OPENSHIFT_PROJECT",
+            "value": "eclipse-che",
+            "required": true
+        },
+        {
+            "description": "OpenShift service account name.",
+            "name": "CHE_OPENSHIFT_SERVICEACCOUNTNAME",
+            "value": "cheserviceaccount",
+            "required": true
+        },
+        {
+            "description": "Che log level (INFO or DEBUG)",
+            "name": "CHE_LOG_LEVEL",
+            "value": "INFO",
+            "required": false
+        },
+        {
+            "description": "IP of the host docker0 bridge. This IP is used by che-server to communicate with che workspaces",
+            "name": "DOCKER0_BRIDGE_IP",
+            "value": "172.17.0.1",
+            "required": true
+        }
+    ],
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080,
+                        "protocol": "TCP",
+                        "name": "tomcat"
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Che http port."
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's http service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                },
+                "port": {
+                    "targetPort": "tomcat"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 75,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}",
+                                "image": "${CHE_SERVER_DOCKER_IMAGE}",
+                                "imagePullPolicy": "Always",
+                                "privileged": true,
+                                "livenessProbe": {
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "readinessProbe": {
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "che-conf-volume",
+                                        "mountPath": "/conf",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "docker-socket-volume",
+                                        "mountPath": "/var/run/docker.sock",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "che-data-volume",
+                                        "mountPath": "/data"
+                                    }
+                                ],
+                                "ports": [
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CHE_DOCKER_MACHINE_HOST_EXTERNAL",
+                                        "value": "${HOSTNAME_HTTP}"
+                                    },
+                                    {
+                                        "name": "CHE_WORKSPACE_STORAGE",
+                                        "value": "/home/user/che/workspaces"
+                                    },
+                                    {
+                                        "name": "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "CHE_LOCAL_CONF_DIR",
+                                        "value": "/etc/conf"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_ENDPOINT",
+                                        "value": "${CHE_OPENSHIFT_ENDPOINT}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_USERNAME",
+                                        "value": "${CHE_OPENSHIFT_USERNAME}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_PASSWORD",
+                                        "value": "${CHE_OPENSHIFT_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_PROJECT",
+                                        "value": "${CHE_OPENSHIFT_PROJECT}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_SERVICEACCOUNTNAME",
+                                        "value": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
+                                    },
+                                    {
+                                        "name": "CHE_IP",
+                                        "value": "${DOCKER0_BRIDGE_IP}"
+                                    },
+                                    {
+                                        "name": "CHE_LOG_LEVEL",
+                                        "value": "${CHE_LOG_LEVEL}"
+                                    }
+                                ],
+                                "args": [],
+                                "securityContext": {
+                                        "privileged": true,
+                                        "runAsUser": 0
+                                }
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "che-conf-volume",
+                                "hostPath": {
+                                    "path": "/etc/conf"
+                                }
+                            },
+                            {
+                                "name": "docker-socket-volume",
+                                "hostPath": {
+                                    "path": "/var/run/docker.sock"
+                                }
+                            },
+                            {
+                                "name": "che-data-volume",
+                                "hostPath": {
+                                    "path": "/home/user/che"
+                                }
+                            }
+                        ],
+                        "serviceAccountName": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/os-templates/che_debug.json
+++ b/os-templates/che_debug.json
@@ -1,0 +1,294 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "description": "Application template for Eclipse Che",
+            "iconClass" : "icon-openjdk",
+            "tags" : "eclipse,che,java,angular,ide",
+            "version" : "5.0.0"
+        },
+        "name": "eclipse-che"
+    },
+    "labels": {
+        "template": "eclipse-che",
+        "xpaas" : "5.0.0"
+    },
+    "parameters": [
+        {
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "che-host",
+            "required": true
+        },
+        {
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTP",
+            "value": "che.openshift.local",
+            "required": false
+        },
+        {
+            "description": "Name of the che-server Docker image.",
+            "name": "CHE_SERVER_DOCKER_IMAGE",
+            "value": "codenvy/che-server:5.0.0-latest",
+            "required": true
+        },
+        {
+            "description": "Url of the OpenShift API",
+            "name": "CHE_OPENSHIFT_ENDPOINT",
+            "value": "",
+            "required": true
+        },
+        {
+            "description": "OpenShift username",
+            "name": "CHE_OPENSHIFT_USERNAME",
+            "value": "openshift-dev",
+            "required": true
+        },
+        {
+            "description": "OpenShift userpassword.",
+            "name": "CHE_OPENSHIFT_PASSWORD",
+            "value": "devel",
+            "required": true
+        },
+        {
+            "description": "OpenShift project.",
+            "name": "CHE_OPENSHIFT_PROJECT",
+            "value": "eclipse-che",
+            "required": true
+        },
+        {
+            "description": "OpenShift service account name.",
+            "name": "CHE_OPENSHIFT_SERVICEACCOUNTNAME",
+            "value": "cheserviceaccount",
+            "required": true
+        },
+        {
+            "description": "Che log level (INFO or DEBUG)",
+            "name": "CHE_LOG_LEVEL",
+            "value": "INFO",
+            "required": false
+        },
+        {
+            "description": "IP of the host docker0 bridge. This IP is used by che-server to communicate with che workspaces",
+            "name": "DOCKER0_BRIDGE_IP",
+            "value": "172.17.0.1",
+            "required": true
+        }
+    ],
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "type": "NodePort",
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080,
+                        "protocol": "TCP",
+                        "name": "tomcat"
+                    },
+                    {
+                        "port": 8000,
+                        "targetPort": 8000,
+                        "protocol": "TCP",
+                        "name": "tomcat-debug"
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Che http port."
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-http",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's http service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                },
+                "port": {
+                    "targetPort": "tomcat"
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 75,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}",
+                                "image": "${CHE_SERVER_DOCKER_IMAGE}",
+                                "imagePullPolicy": "Always",
+                                "privileged": true,
+                                "livenessProbe": {
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "readinessProbe": {
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "che-conf-volume",
+                                        "mountPath": "/conf",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "docker-socket-volume",
+                                        "mountPath": "/var/run/docker.sock",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "che-data-volume",
+                                        "mountPath": "/data"
+                                    }
+                                ],
+                                "ports": [
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CHE_DOCKER_MACHINE_HOST_EXTERNAL",
+                                        "value": "${HOSTNAME_HTTP}"
+                                    },
+                                    {
+                                        "name": "CHE_WORKSPACE_STORAGE",
+                                        "value": "/home/user/che/workspaces"
+                                    },
+                                    {
+                                        "name": "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "CHE_LOCAL_CONF_DIR",
+                                        "value": "/etc/conf"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_ENDPOINT",
+                                        "value": "${CHE_OPENSHIFT_ENDPOINT}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_USERNAME",
+                                        "value": "${CHE_OPENSHIFT_USERNAME}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_PASSWORD",
+                                        "value": "${CHE_OPENSHIFT_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_PROJECT",
+                                        "value": "${CHE_OPENSHIFT_PROJECT}"
+                                    },
+                                    {
+                                        "name": "CHE_OPENSHIFT_SERVICEACCOUNTNAME",
+                                        "value": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
+                                    },
+                                    {
+                                        "name": "CHE_IP",
+                                        "value": "${DOCKER0_BRIDGE_IP}"
+                                    },
+                                    {
+                                        "name": "CHE_LOG_LEVEL",
+                                        "value": "${CHE_LOG_LEVEL}"
+                                    },
+                                    {
+                                        "name": "CHE_DEBUG_SERVER",
+                                        "value": "true"
+                                    }
+                                ],
+                                "args": [],
+                                "securityContext": {
+                                        "privileged": true,
+                                        "runAsUser": 0
+                                }
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "che-conf-volume",
+                                "hostPath": {
+                                    "path": "/etc/conf"
+                                }
+                            },
+                            {
+                                "name": "docker-socket-volume",
+                                "hostPath": {
+                                    "path": "/var/run/docker.sock"
+                                }
+                            },
+                            {
+                                "name": "che-data-volume",
+                                "hostPath": {
+                                    "path": "/home/user/che"
+                                }
+                            }
+                        ],
+                        "serviceAccountName": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/scripts/build_openshift_connector.sh
+++ b/scripts/build_openshift_connector.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+DEFAULT_CHE_IMAGE=codenvy/che-server:local
+
+if [ -z ${GITHUB_REPO+x} ]; then 
+  echo >&2 "Variable GITHUB_REPO not found. Aborting"
+  exit 1
+fi
+
+CHE_IMAGE=${CHE_IMAGE:-${DEFAULT_CHE_IMAGE}}
+
+CURRENT_DIR=$(pwd)
+cd ${GITHUB_REPO}
+
+mvnche() {
+  mvn -Dskip-enforce -Dskip-validate-sources -DskipTests -Dfindbugs.skip -Dgwt.compiler.localWorkers=2 -T 1C -Dskip-validate-sources $@
+}
+
+cd plugins/plugin-docker
+mvnche clean install
+cd ../..
+
+cd wsmaster/che-core-api-agent
+mvnche clean install
+cd ../che-core-api-workspace
+mvnche clean install
+cd ../..
+
+cd assembly/assembly-wsmaster-war
+mvnche clean install
+cd ../..
+
+cd assembly/assembly-main/
+mvnche clean install
+cd ../..
+
+docker build -t ${CHE_IMAGE} .
+cd ${CURRENT_DIR}


### PR DESCRIPTION
Copy templates and scripts to deploy Che on OpenShift from github.com/l0rd/openche 