### PR TITLE
Change templates to accomodate 5.1.0 release of Che

### DIFF
--- a/os-templates/che.json
+++ b/os-templates/che.json
@@ -203,7 +203,7 @@
                                 ],
                                 "env": [
                                     {
-                                        "name": "CHE_DOCKER_MACHINE_HOST_EXTERNAL",
+                                        "name": "CHE_DOCKER_IP_EXTERNAL",
                                         "value": "${HOSTNAME_HTTP}"
                                     },
                                     {
@@ -239,7 +239,7 @@
                                         "value": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
                                     },
                                     {
-                                        "name": "CHE_IP",
+                                        "name": "CHE_DOCKER_IP",
                                         "value": "${DOCKER0_BRIDGE_IP}"
                                     },
                                     {

--- a/os-templates/che_debug.json
+++ b/os-templates/che_debug.json
@@ -211,7 +211,7 @@
                                 ],
                                 "env": [
                                     {
-                                        "name": "CHE_DOCKER_MACHINE_HOST_EXTERNAL",
+                                        "name": "CHE_DOCKER_IP_EXTERNAL",
                                         "value": "${HOSTNAME_HTTP}"
                                     },
                                     {
@@ -247,7 +247,7 @@
                                         "value": "${CHE_OPENSHIFT_SERVICEACCOUNTNAME}"
                                     },
                                     {
-                                        "name": "CHE_IP",
+                                        "name": "CHE_DOCKER_IP",
                                         "value": "${DOCKER0_BRIDGE_IP}"
                                     },
                                     {


### PR DESCRIPTION
Change which env vars are bound in Che templates. Prior
to 5.1.0, CHE_DOCKER_MACHINE_HOST_EXTERNAL would override all
other properties in setting external hostname. Instead we now use
CHE_DOCKER_IP_EXTERNAL, which should have the same effect in all
versions of Che.

Additionally, 5.1.0 has a bug where setting CHE_IP does not have
the correct effect. This is can be worked around by setting
CHE_DOCKER_IP instead, which is the property that CHE_IP is
used to override.

@ibuziuk Can you test if these changes fix the cannot ping wsagent issue in your current rebase?