### PR TITLE
Update default Che Docker image to rhche/che-server:nightly

### DIFF
--- a/os-templates/README.md
+++ b/os-templates/README.md
@@ -5,7 +5,7 @@ Scripts, patchs and templates to run Eclipse Che on OpenShift
 
 1\. [Optional] Build Che (`openshift-connector` branch) 
 
-This step is optional: the Docker image is already built and available on Docker Hub `mariolet/che-server:openshiftconnector`.
+This step is optional: the Docker image is already built and available on Docker Hub `rhche/che-server:nightly`.
 
 Instructions to build the image:
 
@@ -29,8 +29,8 @@ npm install -g bower gulp typings
 mvn clean install -Pfast
 
 # Build docker image and push it to a registry
-docker build -t mariolet/che-server:openshiftconnector .
-docke push mariolet/che-server:openshiftconnector
+docker build -t rhche/che-server:nightly
+docker push rhche/che-server:nightly
 ```
 
 2\. Configure OpenShift
@@ -56,7 +56,7 @@ cd rh-che/scripts
 oc login -u openshift-dev che.ci.centos.org
 export CHE_HOSTNAME=demo.che.ci.centos.org
 export CHE_OPENSHIFT_ENDPOINT=https://che.ci.centos.org:8443/
-export CHE_IMAGE=mariolet/che-server:openshiftconnector
+export CHE_IMAGE=rhche/che-server:nightly
 export DOCKER0_IP=10.1.0.1
 export CHE_LOG_LEVEL=INFO
 export CHE_OPENSHIFT_USERNAME=<replacewithusername>
@@ -106,7 +106,7 @@ cd rh-che/scripts
 oc login -u openshift-dev -p devel
 
 export CHE_HOSTNAME=che.openshift.mini
-export CHE_IMAGE=eclipse/che-server:nightly
+export CHE_IMAGE=rhche/che-server:nightly
 export DOCKER0_IP=$(docker run -ti --rm --net=host alpine ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
 export CHE_OPENSHIFT_ENDPOINT=https://$(minishift ip):8443
 docker pull $CHE_IMAGE
@@ -118,7 +118,7 @@ docker pull $CHE_IMAGE
 ```
 Once the pod is successfully started Che dashboard should be now available on the minishift console.
 
->`./build_openshift_connector.sh` script can be used for building `eclipse/che-server:nightly` image locally
+>`./build_openshift_connector.sh` script can be used for building `rhche/che-server:nightly` image locally
 
 ## Deployment of Che on ADB (deprecated, use minishift instead)
 
@@ -173,7 +173,7 @@ cd rh-che
 # Prepare the environment
 oc login -u openshift-dev -p devel
 export CHE_HOSTNAME=che.openshift.adb
-export CHE_IMAGE=codenvy/che-server:5.0.0-latest
+export CHE_IMAGE=rhche/che-server:nightly
 docker pull $CHE_IMAGE
 # If a previous version of Che was deployed, delete it
 ./openche.sh delete

--- a/os-templates/che.json
+++ b/os-templates/che.json
@@ -30,7 +30,7 @@
         {
             "description": "Name of the che-server Docker image.",
             "name": "CHE_SERVER_DOCKER_IMAGE",
-            "value": "eclipse/che-server:nightly",
+            "value": "rhche/che-server:nightly",
             "required": true
         },
         {

--- a/os-templates/che_debug.json
+++ b/os-templates/che_debug.json
@@ -30,7 +30,7 @@
         {
             "description": "Name of the che-server Docker image.",
             "name": "CHE_SERVER_DOCKER_IMAGE",
-            "value": "eclipse/che-server:nightly",
+            "value": "rhche/che-server:nightly",
             "required": true
         },
         {

--- a/scripts/build_openshift_connector.sh
+++ b/scripts/build_openshift_connector.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+DEFAULT_CHE_IMAGE_REPO=rhche/che-server
 DEFAULT_CHE_IMAGE_TAG=nightly
 
 if [ -z ${GITHUB_REPO+x} ]; then 
@@ -9,6 +10,7 @@ if [ -z ${GITHUB_REPO+x} ]; then
   exit 1
 fi
 
+CHE_IMAGE_REPO=${CHE_IMAGE_REPO:-${DEFAULT_CHE_IMAGE_REPO}}
 CHE_IMAGE_TAG=${CHE_IMAGE_TAG:-${DEFAULT_CHE_IMAGE_TAG}}
 
 CURRENT_DIR=$(pwd)
@@ -32,6 +34,7 @@ cd ../..
 
 cd dockerfiles/che/
 ./build.sh ${CHE_IMAGE_TAG}
+docker tag eclipse/che-server:${CHE_IMAGE_TAG} ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
 
 cd ${CURRENT_DIR}
 

--- a/scripts/openche.sh
+++ b/scripts/openche.sh
@@ -36,7 +36,7 @@
 set_parameters() {
     echo "Setting parameters"
     DEFAULT_CHE_HOSTNAME=che.openshift.mini
-    DEFAULT_CHE_IMAGE=eclipse/che-server:nightly
+    DEFAULT_CHE_IMAGE=rhche/che-server:nightly
     DEFAULT_CHE_LOG_LEVEL=DEBUG
     DEFAULT_CHE_TEMPLATE="../os-templates/che.json"
     DEFAULT_CHE_OPENSHIFT_USERNAME="openshift-dev"


### PR DESCRIPTION
We have setup a jenkins job to automatically build and publish a CentOS based Che image to rhche/che-server:nightly every night. 

This should be the default image used to deploy Che on OpenShift.