### PR TITLE
Use an env variable to set Che version used in create_all.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,6 +55,8 @@ mv Dockerfile Dockerfile.alpine
 cp Dockerfile.centos Dockerfile
 ./build.sh ${CHE_IMAGE_TAG}
 mv Dockerfile.alpine Dockerfile
+
+echo "Tagging eclipse/che-server:${CHE_IMAGE_TAG} ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}"
 docker tag eclipse/che-server:${CHE_IMAGE_TAG} ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
 
 cd ${CURRENT_DIR}

--- a/scripts/create-all.sh
+++ b/scripts/create-all.sh
@@ -98,7 +98,7 @@ $(cat ${FABRIC8_ONLINE_PATH}apps/che/src/main/fabric8/deployment.yml)
     project: che
     provider: fabric8
 " |  \
-sed "s/image:.*/image: \"rhche\/che-server:nightly\"/g" | \
+sed "s/image:.*/image: \"${CHE_SERVER_IMAGE}\"/g" | \
 oc apply -f -
 
 #Create Che service

--- a/scripts/setenv-for-deploy.sh
+++ b/scripts/setenv-for-deploy.sh
@@ -6,3 +6,4 @@ export CHE_HOSTNAME="che.$(minishift ip).nip.io"
 export CHE_LOG_LEVEL="DEBUG"
 export CHE_DEBUGGING_ENABLED="true"
 export FABRIC8_ONLINE_PATH="${HOME}/github/fabric8-online/"
+export CHE_SERVER_IMAGE=rhche\\/che-server:nightly


### PR DESCRIPTION
Add a new environment variable ($CHE_SERVER_IMAGE) to configure the version of Che image that will be deployed with `create_all.sh`.