### PR TITLE
Remove unnecessary web applications from the RedHat Che distribution

### DIFF
--- a/assembly/assembly-main/src/assembly/assembly.xml
+++ b/assembly/assembly-main/src/assembly/assembly.xml
@@ -60,6 +60,8 @@
                 <exclude>**/tomcat/webapps/wsmaster.war</exclude>
                 <exclude>**/lib/ws-agent.tar.gz</exclude>
                 <exclude>**/tomcat/webapps/dashboard.war</exclude>
+                <exclude>**/tomcat/webapps/swagger.war</exclude>
+                <exclude>**/tomcat/webapps/docs.war</exclude>
             </excludes>
         </fileSet>
         <fileSet>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -11,7 +11,7 @@
         <artifactId>fabric8-ide-parent</artifactId>
         <groupId>com.redhat.che</groupId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../invoker/rh-changes</relativePath>
+        <relativePath>../target/rh-changes</relativePath>
     </parent>
     <artifactId>fabric8-ide-assembly-parent</artifactId>
     <version>${redhat.che.version}</version>

--- a/invoker/rh-changes/pom.xml
+++ b/invoker/rh-changes/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.6.0-openshift-connector-SNAPSHOT</version>
+        <version>@che.version@</version>
         <relativePath>@baseCheRepository@</relativePath>
     </parent>
     <groupId>com.redhat.che</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -11,7 +11,7 @@
         <artifactId>fabric8-ide-parent</artifactId>
         <groupId>com.redhat.che</groupId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../invoker/rh-changes</relativePath>
+        <relativePath>../target/rh-changes</relativePath>
     </parent>
     <artifactId>fabric8-ide-plugins-parent</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -229,15 +229,23 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <cloneProjectsTo>${basedir}/target</cloneProjectsTo>
                     <streamLogs>true</streamLogs>
-                    <projectsDirectory>${basedir}</projectsDirectory>
+                    <projectsDirectory>${basedir}/invoker</projectsDirectory>
                     <pomIncludes>
-                        <pomInclude>invoker/rh-changes/pom.xml</pomInclude>
+                        <pomInclude>rh-changes/pom.xml</pomInclude>
                     </pomIncludes>
+                    <filterProperties>
+                        <baseCheRepository>${baseCheRepository}</baseCheRepository>
+                        <withoutDashboard>${withoutDashboard}</withoutDashboard>
+                        <redhat.che.version>${redhat.che.version}</redhat.che.version>
+                        <che.version>${che.version}</che.version>
+                    </filterProperties>
                     <properties>
                         <baseCheRepository>${baseCheRepository}</baseCheRepository>
                         <withoutDashboard>${withoutDashboard}</withoutDashboard>
                         <redhat.che.version>${redhat.che.version}</redhat.che.version>
+                        <che.version>${che.version}</che.version>
                     </properties>
                     <debug>false</debug>
                 </configuration>
@@ -377,7 +385,7 @@
                                 <id>RedHat assembly build</id>
                                 <configuration>
                                     <setupIncludes>
-                                        <setupInclude>invoker/base-che/pom.xml</setupInclude>
+                                        <setupInclude>base-che/pom.xml</setupInclude>
                                     </setupIncludes>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,33 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>clean without export</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <excludes>
+                                        <exclude>export/**</exclude>
+                                    </excludes>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
@@ -247,26 +274,6 @@
             <properties>
                 <baseCheRepository>${project.build.directory}/export/che-dependencies/che</baseCheRepository>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-clean-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>target</directory>
-                                    <excludes>
-                                        <exclude>export/**</exclude>
-                                    </excludes>
-                                    <followSymlinks>false</followSymlinks>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>checkout-base-che</id>
@@ -277,6 +284,30 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>clean Export</id>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>target</directory>
+                                            <includes>
+                                                <exclude>export/**</exclude>
+                                            </includes>
+                                            <followSymlinks>false</followSymlinks>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-plugin</artifactId>
@@ -367,22 +398,6 @@
             </properties>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-clean-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>target</directory>
-                                    <excludes>
-                                        <exclude>export/**</exclude>
-                                    </excludes>
-                                    <followSymlinks>false</followSymlinks>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>buildnumber-maven-plugin</artifactId>


### PR DESCRIPTION
This PR:
- removes the `swagger` and `docs` web applications from the final RedHat Che distribution
- fixes a small bug in the build (`target/export` was not correctly cleaned in some cases) 