### PR TITLE
Add binding to OpenShiftWorkspaceFilesCleaner in WsMasterModule

### DIFF
--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
@@ -180,6 +180,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-openshift-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-ssh-machine</artifactId>
         </dependency>
         <dependency>

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -179,7 +179,7 @@ public class WsMasterModule extends AbstractModule {
         requestInjection(interceptor);
         bindInterceptor(subclassesOf(CheJsonProvider.class), names("readFrom"), interceptor);
         bind(org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner.class)
-                .to(org.eclipse.che.plugin.docker.machine.cleaner.LocalWorkspaceFilesCleaner.class);
+		.to(org.eclipse.che.plugin.openshift.client.OpenShiftWorkspaceFilesCleaner.class);
         bind(org.eclipse.che.api.environment.server.InfrastructureProvisioner.class)
                 .to(org.eclipse.che.plugin.docker.machine.local.LocalCheInfrastructureProvisioner.class);
 


### PR DESCRIPTION
Looks like we missed a binding in WsMasterModule on upstream Che. OpenShiftWorkspaceFilesCleaner is necessary to avoid NPEs and properly delete files in PVs.

See: https://issues.jboss.org/browse/CHE-181