### PR TITLE
Add support for image tags other than nightly in build/create scripts.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ cd ../..
 cd dockerfiles/che/
 mv Dockerfile Dockerfile.alpine
 cp Dockerfile.centos Dockerfile
-./build.sh ${CHE_IMAGE_TAG}
+./build.sh --tag:${CHE_IMAGE_TAG}
 mv Dockerfile.alpine Dockerfile
 docker tag eclipse/che-server:${CHE_IMAGE_TAG} ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
 

--- a/scripts/create-all.sh
+++ b/scripts/create-all.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+DEFAULT_CHE_IMAGE_REPO=rhche/che-server
+DEFAULT_CHE_IMAGE_TAG=nightly
+
+CHE_IMAGE_REPO=${CHE_IMAGE_REPO:-${DEFAULT_CHE_IMAGE_REPO}}
+CHE_IMAGE_TAG=${CHE_IMAGE_TAG:-${DEFAULT_CHE_IMAGE_TAG}}
+
+CHE_IMAGE_REPO=$(echo $CHE_IMAGE_REPO | sed 's/\//\\\//g')
+
 # minishift is running
 echo "# Checking if minishift is running..."
 minishift status | grep -q "Running" ||(echo "Minishift is not running. Aborting"; exit 1)
@@ -99,7 +107,7 @@ $(cat ${FABRIC8_ONLINE_PATH}apps/che/src/main/fabric8/deployment.yml)
     project: che
     provider: fabric8
 " |  \
-sed "s/image:.*/image: \"rhche\/che-server:nightly\"/g" | \
+sed "s/image:.*/image: \"${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}\"/g" | \
 oc apply -f -
 
 #Create Che service


### PR DESCRIPTION
Minor modifications to make build.sh and create-all.sh support `CHE_IMAGE_TAG` correctly.