### PR TITLE
Add param for subpath creation to create-all.sh

### DIFF
--- a/scripts/create-all.sh
+++ b/scripts/create-all.sh
@@ -48,7 +48,8 @@ oc create configmap che \
       --from-literal=che-workspaces-java-opts="-XX:+UseSerialGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1300m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
       --from-literal=che-openshift-secure-routes="false" \
       --from-literal=che-secure-external-urls="false" \
-      --from-literal=che-server-timeout-ms="0"
+      --from-literal=che-server-timeout-ms="0" \
+      --from-literal=che-openshift-precreate-subpaths="true"
 
 # Deploy PVs (gofabric8 way)
 #   gofabric8 should be installed:


### PR DESCRIPTION
Add configmap value `che-openshift-precreate-subpaths`. If false, Che server will not manually create workspace subpaths before mounting them to a workspace pod. Depends on an OpenShift version with fix for https://github.com/kubernetes/kubernetes/issues/41638 and pull request https://github.com/fabric8io/fabric8-online/pull/219.

From my testing, it looks like none of the versions of OpenShift available in minishift include the kubernetes fix, so it's better to set the property to true for local development.

Upstream Che PR: https://github.com/eclipse/che/pull/5008