### PR TITLE
Make the Maven build compatible with M2Eclipse

### DIFF
--- a/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
@@ -24,6 +24,46 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>exec-maven-plugin</artifactId>
+                            <versionRange>[1.4.0,)</versionRange>
+                            <goals>
+                              <goal>java</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore />
+                          </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.eclipse.che.core</groupId>
+                            <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                            <versionRange>[4,)</versionRange>
+                            <goals>
+                              <goal>generate</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore />
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -213,6 +253,21 @@
                                     version =
                                     ${project.version}</echo>
                             </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean generated sources in assembly-ide-war</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- To bypass a problem in the build when 
+                                    rebuilding without the clean option. -->
+                                <delete verbose="true"
+                                    dir="${project.build.directory}/generated-sources" />
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/builds/fabric8-che/pom.xml
+++ b/builds/fabric8-che/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>@che.version@</version>
+        <version>5.13.0-SNAPSHOT</version>
         <relativePath>@baseCheRepository@</relativePath>
     </parent>
     <groupId>com.redhat.che</groupId>
@@ -197,6 +197,14 @@
                 </executions>
             </plugin>
             <plugin>
+              <groupId>com.google.code.sortpom</groupId>
+              <artifactId>maven-sortpom-plugin</artifactId>
+              <inherited>false</inherited>
+              <configuration>
+                <sortProperties>false</sortProperties>
+              </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -248,8 +256,82 @@
                             <excludeDefaultDirectories>true</excludeDefaultDirectories>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>expected-versions</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>project.parent.version</property>
+                                            <regex>${che.version}</regex>
+                                            <message>The version of the
+                                                parent pom (${project.parent.version}) is not
+                                                the same as the one specified by
+                                                the 'che.version' property
+                                                (${che.version}) that is defined
+                                                in the Git repository root build ('rh-che/pom.xml')</message>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>startedDirectly</id>
+            <activation>
+                <property>
+                    <name>startedByInvoker</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>alwaysFail</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>startedByInvoker</property>
+                                            <regex>true</regex>
+                                            <message>The build should always be run from the root of the Git repository
+                                                ('rh-che/pom.xml'). See the Readme for more details.</message>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <!--  These 2 properties are used for the m2e intregration 
+                      and should be consistent with the 'che.version' property
+                      defined in the defined in the root build ('fabric8-ide-builder/pom.xml') -->
+                <che.version.prefix>5.13.0</che.version.prefix>
+                <che.version.suffix>-SNAPSHOT</che.version.suffix>
+
+                <che.version>${che.version.prefix}${che.version.suffix}</che.version>
+                <redhat.che.version>${che.version.prefix}-fabric8${che.version.suffix}</redhat.che.version>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,8 @@
                                     rebuilding without the clean option. -->
                                 <delete
                                     dir="${project.build.directory}/builds/${redhat-version-qualifier}/fabric8-che/assembly/assembly-ide-war/target/generated-sources" />
+                                <delete
+                                    dir="${basedir}/builds/fabric8-che/assembly/assembly-ide-war/target/generated-sources" />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
#### Description of the problem 

The RH distribution build has several strong requirements such as:
- Producing several variants of the RH Che distribution with a single build, while ensuring that the build process and intermediate artifacts of each variant are fully isolated,
- Deriving the version number of the produced RH Che distribution assembly artifacts (for all variants) from the version of the upstream Che,
- Reusing ( and modifying / completing ) *both the source and the generated artifacts* of some upstream Che maven modules (e.g. the `assembly-ide-war` GWT application) to provide the variants of the RH Che distribution artifacts,
- Checking out the a given branch of the upstream Che version and building it when the build is used by CI.

To meet these requirements, the maven build has a specific structure (using the maven `invoker` plugin) that, until now, was *not compatible with the M2Eclipse integration*. This prevented using JDT services (completion, cross-references, etc ...) on modules that are also Java projects (such as the plugins or the `assembly-wsmaster-war`)

#### Description of the Fix

This PR introduces slight changes that allow importing the RH distribution maven sub-modules *as Maven projects in Eclipse*. For projects that are Java projects, M2Eclipse can now correctly calculate the classpath based on the Maven POM file, and all the services of JDT are available again.
However the main structure of the build is not impacted, so that it doesn't impact / break the requirements described [above](description-of-the-problem).  
 
Signed-off-by: David Festal <dfestal@redhat.com>