### PR TITLE
Add configmap entry to disable workspace snapshots

### DIFF
--- a/dev-scripts/minishift_deploy.sh
+++ b/dev-scripts/minishift_deploy.sh
@@ -75,7 +75,8 @@ oc create configmap che \
       --from-literal=che-server-timeout-ms="0" \
       --from-literal=che-openshift-precreate-subpaths="true" \
       --from-literal=keycloak-oso-endpoint="https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token" \
-      --from-literal=keycloak-github-endpoint="https://sso.openshift.io/auth/realms/fabric8/broker/github/token"
+      --from-literal=keycloak-github-endpoint="https://sso.openshift.io/auth/realms/fabric8/broker/github/token" \
+      --from-literal=che-workspace-auto-snapshot="false"
 
 # Deploy PVs (gofabric8 way)
 #   gofabric8 should be installed:


### PR DESCRIPTION
Che is by default taking "snapshots" of workspaces on shutdown. Adding the env var `CHE_WORKSPACE_AUTO__SNAPSHOT=false` disables this.

Not an urgent merge, since I don't think the pseudo-snapshots we're taking actually uses many resources.

Issue: https://github.com/redhat-developer/rh-che/issues/109
Depends on: https://github.com/fabric8io/fabric8-online/pull/245