### PR TITLE
Fix #124 by selecting the stack policy for loading the content of stack.json

### DIFF
--- a/dev-scripts/minishift_deploy.sh
+++ b/dev-scripts/minishift_deploy.sh
@@ -60,6 +60,7 @@ oc create configmap che \
       --from-literal=che-server-evaluation-strategy="single-port" \
       --from-literal=che.docker.server_evaluation_strategy.custom.template="<serverName>-<if(isDevMachine)><workspaceIdWithoutPrefix><else><machineName><endif>-<externalAddress>" \
       --from-literal=che.docker.server_evaluation_strategy.custom.external.protocol="https" \
+      --from-literal=che.predefined.stacks.reload_on_start="true" \
       --from-literal=log-level=${CHE_LOG_LEVEL} \
       --from-literal=docker-connector="openshift" \
       --from-literal=port="8080" \


### PR DESCRIPTION
### What does this PR do?
Policy on loading stacks has been changed. In order to keep previous policy, a flag needs to be set

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/124

#### Changelog
Update policy for loading stacks.json file