### PR TITLE
Use of fabric8 ide stacks

### DIFF
--- a/builds/fabric8-che/assembly/assembly-main/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-main/pom.xml
@@ -41,28 +41,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-stack</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <loadfile property="stack.che-in-che" srcFile="${project.basedir}/src/assembly/stack/che-in-che.json" />
-                                <unzip dest="${project.build.directory}/stacks" src="${com.redhat.che:fabric8-ide-stacks:jar}" />
-                                <replaceregexp file="${project.build.directory}/stacks/stacks.json" flags="m">
-                                    <regexp pattern="^]$" />
-                                    <substitution expression=", ${stack.che-in-che} ]" />
-                                </replaceregexp>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
@@ -42,11 +42,21 @@
             <groupId>org.eclipse.che</groupId>
             <artifactId>assembly-wsmaster-war</artifactId>
             <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.che.core</groupId>
+                    <artifactId>che-core-ide-stacks</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.redhat.che</groupId>
+            <artifactId>fabric8-ide-stacks</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -100,20 +110,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <configuration>
-                            <overlays>
-                                <overlay>
-                                    <groupId>org.eclipse.che</groupId>
-                                    <artifactId>assembly-wsmaster-war</artifactId>
-                                    <type>war</type>
-                                </overlay>
-                            </overlays>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                <configuration>
+                    <overlays>
+                        <overlay>
+                            <groupId>org.eclipse.che</groupId>
+                            <artifactId>assembly-wsmaster-war</artifactId>
+                            <type>war</type>
+                            <excludes>
+                                <exclude>WEB-INF/lib/che-core-ide-stacks-${che.version}.jar</exclude>
+                                <exclude>WEB-INF/classes/che-in-che.json</exclude>
+                            </excludes>
+                        </overlay>
+                    </overlays>
+                </configuration>
+           </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### What does this PR do?
- Remove ant-run tasks and default eclipse che jar providing stacks and provide the fabric8 ide stack.jar
- Also fix the invalid configuration of maven-war-plugin overlay which was not applied.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/124

#### Changelog
Use of custom fabric8 IDE stacks


Change-Id: I6f9d5597bada8f0f9496358731117750e7ffa24a
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>