### PR TITLE
Fix workspace keycloak authentication

### DIFF
--- a/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
@@ -352,7 +352,6 @@
                             <groupId>org.eclipse.che.plugin</groupId>
                         </exclusion>
                     </exclusions>
-                    
                 </dependency>
             </dependencies>
         </profile>

--- a/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/META-INF/context.xml.patch
+++ b/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/META-INF/context.xml.patch
@@ -4,5 +4,5 @@
  -->
  <Context allowCasualMultipartParsing="true">
      <Valve className="org.apache.catalina.valves.rewrite.RewriteValve"/>
-+    <Valve className="org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve"/>
++    <Valve className="com.redhat.che.valve.UserAuthValve"/>
  </Context>

--- a/builds/fabric8-che/assembly/assembly-main/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-main/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>fabric8-ide-assembly-wsmaster-war</artifactId>
             <type>war</type>
         </dependency>
+        <dependency>
+            <groupId>com.redhat.che</groupId>
+            <artifactId>user-auth-valve</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -91,6 +95,24 @@
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/keycloak</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-user-auth-valve</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.redhat.che</groupId>
+                                    <artifactId>user-auth-valve</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/keycloak</outputDirectory>
+                                    <type>jar</type>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/builds/fabric8-che/assembly/assembly-wsagent-server/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-wsagent-server/pom.xml
@@ -66,6 +66,42 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>package-keycloak-adapter</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.keycloak</groupId>
+                                    <artifactId>keycloak-tomcat8-adapter-dist</artifactId>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/keycloak</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-user-auth-valve</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.redhat.che</groupId>
+                                    <artifactId>user-auth-valve</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/keycloak</outputDirectory>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/builds/fabric8-che/assembly/assembly-wsagent-server/src/assembly/assembly.xml
+++ b/builds/fabric8-che/assembly/assembly-wsagent-server/src/assembly/assembly.xml
@@ -37,5 +37,9 @@
                 <exclude>**/webapps/ROOT.war</exclude>
             </excludes>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/keycloak/</directory>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/builds/fabric8-che/assembly/pom.xml
+++ b/builds/fabric8-che/assembly/pom.xml
@@ -23,6 +23,7 @@
         <module>assembly-ide-war</module>
         <module>assembly-wsmaster-war</module>
         <module>assembly-main</module>
+        <module>user-auth-valve</module>
     </modules>
     <build>
         <pluginManagement>

--- a/builds/fabric8-che/assembly/user-auth-valve/pom.xml
+++ b/builds/fabric8-che/assembly/user-auth-valve/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (c) 2017 Red Hat Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat Inc. - initial API and implementation
+
+-->
+
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>fabric8-ide-assembly-parent</artifactId>
+        <groupId>com.redhat.che</groupId>
+        <version>@redhat.che.version@</version>
+    </parent>
+    <artifactId>user-auth-valve</artifactId>
+    <name>user-auth-valve</name>
+    <url>http://maven.apache.org</url>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-tomcat8-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/builds/fabric8-che/assembly/user-auth-valve/src/main/java/com/redhat/che/valve/UserAuthValve.java
+++ b/builds/fabric8-che/assembly/user-auth-valve/src/main/java/com/redhat/che/valve/UserAuthValve.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat inc.
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package com.redhat.che.valve;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.catalina.connector.Request;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performs Keycloak and OpenShift.io user validation. Prompts user to login if necessary
+ * and checks if the logged in user has access to the current Che instance.
+ *
+ * @see KeycloakAuthenticatorValve
+ *
+ * @author amisevsk
+ */
+public class UserAuthValve extends KeycloakAuthenticatorValve {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UserAuthValve.class);
+    private static final String USER_VALIDATOR_ENDPOINT = "http://che-host:8080/api/token/user";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Override
+    public boolean authenticate(Request request, HttpServletResponse response) throws IOException {
+        if (super.authenticate(request, response)) {
+            String auth = getToken(request);
+            if (auth != null && userMatches(auth)) {
+                return true;
+            }
+            response.sendError(403);
+        }
+        return false;
+    }
+
+    /**
+     * Verify that a logged in user has access to the current project by making a request
+     * against the /api/token/user endpoing on Che server.
+     *
+     * <p> Base URL for the request is set to the default service name for Eclipse Che ({@code che-host})
+     * @param keycloakToken value of the auth header on the request (i.e. the keycloak token).
+     * @return true if the user matches the current project owner, false otherwise
+     */
+    private boolean userMatches(String keycloakToken) {
+        URL url;
+        HttpURLConnection conn;
+        try {
+            url = new URL(USER_VALIDATOR_ENDPOINT);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.addRequestProperty(AUTHORIZATION_HEADER, keycloakToken);
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = in.readLine()) != null) {
+                response.append(line);
+            }
+            return "true".equals(response.toString());
+        } catch (IOException e) {
+            LOG.error("Exception while validating user: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Gets keycloak token from request.
+     * @param request
+     * @return
+     */
+    private String getToken(Request request) {
+        KeycloakSecurityContext ksc =
+                (KeycloakSecurityContext)request.getAttribute(KeycloakSecurityContext.class.getName());
+        String auth = ksc.getTokenString();
+        return auth;
+    }
+}

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
@@ -9,6 +9,7 @@
  * Contributors:
  *     Red Hat - Initial Contribution
  *******************************************************************************/
+
 package com.redhat.che.keycloak.server;
 
 import java.io.IOException;
@@ -24,9 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.KeycloakOIDCFilter {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
 
+    @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
             throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) req;
@@ -42,9 +44,13 @@ public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.
                 || isInternalRequest(authHeader)) {
             LOG.debug("Skipping {}", requestURI);
             chain.doFilter(req, res);
-        } else {
+        } else if (KeycloakUserChecker.matchesUsername(authHeader)) {
             super.doFilter(req, res, chain);
             LOG.debug("{} status : {}", request.getRequestURL(), ((HttpServletResponse) res).getStatus());
+        } else {
+            HttpServletResponse response = (HttpServletResponse) res;
+            response.sendError(403);
+            return;
         }
     }
 
@@ -63,7 +69,7 @@ public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.
 
     private boolean isWebsocketRequest(String requestURI, String requestScheme) {
         return requestURI.endsWith("/ws") || requestURI.endsWith("/eventbus") || requestScheme.equals("ws")
-                || requestScheme.equals("wss") || requestURI.contains("/websocket/");
+                || requestScheme.equals("wss") || requestURI.contains("/websocket/")
+                || requestURI.endsWith("/token/user");
     }
-
 }

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakHttpJsonRequestFactory.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakHttpJsonRequestFactory.java
@@ -28,13 +28,11 @@ public class KeycloakHttpJsonRequestFactory extends DefaultHttpJsonRequestFactor
 
     @Override
     public HttpJsonRequest fromUrl(@NotNull String url) {
-        System.out.println(" setAuthorizationHeader for " + url);
         return super.fromUrl(url).setAuthorizationHeader("Internal");
     }
 
     @Override
     public HttpJsonRequest fromLink(@NotNull Link link) {
-        System.out.println(" setAuthorizationHeader for " + link);       
         return super.fromLink(link).setAuthorizationHeader("Internal");
     }
 

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat inc.
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package com.redhat.che.keycloak.server;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+public class KeycloakUserChecker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakUserChecker.class);
+    private static final String ENDPOINT = "http://che-host:8080/api/token/user";
+
+    /**
+     * Cache that stores mappings from user to authorization status.
+     */
+    private static LoadingCache<String, Boolean> cache = CacheBuilder.newBuilder()
+            .maximumSize(100)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .build(new CacheLoader<String, Boolean>() {
+                @Override
+                public Boolean load(String auth) throws Exception {
+                    try {
+                        String response = new KeycloakHttpJsonRequestFactory().fromUrl(ENDPOINT)
+                                                                              .useGetMethod()
+                                                                              .setAuthorizationHeader(auth)
+                                                                              .request().asString();
+                        return "true".equals(response);
+                    } catch (ServerException | UnauthorizedException | ForbiddenException | NotFoundException
+                            | ConflictException | BadRequestException | IOException e) {
+                        e.printStackTrace();
+                    }
+                    return false;
+                }
+            });
+
+    /**
+     * Check if a provided keycloak token matches the OpenShift user that owns the current
+     * namespace.
+     * @param auth the keycloak token
+     * @return true if keycloak token is assigned to owner of namespace, false otherwise.
+     */
+    public static boolean matchesUsername(String auth) {
+        if (auth == null) {
+            return false;
+        }
+        try {
+            Boolean userMatches = cache.get(auth);
+            if (userMatches != null) {
+                return userMatches;
+            }
+        } catch (ExecutionException e) {
+            LOG.error("Exception while checking user auth: {}", e.getMessage());
+        }
+        return false;
+    }
+
+}

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/pom.xml
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/pom.xml
@@ -40,6 +40,14 @@
             <artifactId>google-oauth-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.redhat.che</groupId>
+            <artifactId>che-keycloak-plugin-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -70,6 +78,10 @@
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-github-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/contoller/TokenController.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/contoller/TokenController.java
@@ -38,6 +38,7 @@ import org.eclipse.che.security.oauth.OAuthAuthenticatorProvider;
 import com.redhat.che.keycloak.token.provider.exception.KeycloakException;
 import com.redhat.che.keycloak.token.provider.oauth.OpenShiftGitHubOAuthAuthenticator;
 import com.redhat.che.keycloak.token.provider.service.KeycloakTokenProvider;
+import com.redhat.che.keycloak.token.provider.util.KeycloakUserValidator;
 import com.redhat.che.keycloak.token.provider.validator.KeycloakTokenValidator;
 
 @Path("/token")
@@ -50,6 +51,9 @@ public class TokenController {
 
     @Inject
     private KeycloakTokenValidator validator;
+
+    @Inject
+    private KeycloakUserValidator userValidator;
 
     @Inject
     protected OAuthAuthenticatorProvider providers;
@@ -105,10 +109,20 @@ public class TokenController {
         try {
             validator.validate(keycloakToken);
             token = tokenProvider.obtainOsoToken(keycloakToken);
-        } catch (KeycloakException e) {
+        } catch (Exception e) {
             return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
         }
         return Response.ok(token).build();
+    }
+
+    @GET
+    @Path("/user")
+    public Response getUserMatches(@HeaderParam(HttpHeaders.AUTHORIZATION) String keycloakToken) {
+        if (userValidator.matchesUsername(keycloakToken)) {
+            return Response.ok("true").build();
+        } else {
+            return Response.ok("false").build();
+        }
     }
 
 }

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/service/KeycloakTokenProvider.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/service/KeycloakTokenProvider.java
@@ -50,23 +50,23 @@ public class KeycloakTokenProvider {
 
     /**
      * Return GitHub access token based on Keycloak token
-     * 
+     *
      * <p>
-     * Note: valid response from keycloak endpoint: 
+     * Note: valid response from keycloak endpoint:
      *       access_token=token&scope=scope&token_type=bearer
      * </p>
-     * 
+     *
      * @param keycloakToken
-     * 
-     * @return GitHub access token 
-     * @throws IOException 
-     * @throws BadRequestException 
-     * @throws ConflictException 
-     * @throws NotFoundException 
-     * @throws ForbiddenException 
-     * @throws UnauthorizedException 
-     * @throws ServerException 
-     * 
+     *
+     * @return GitHub access token
+     * @throws IOException
+     * @throws BadRequestException
+     * @throws ConflictException
+     * @throws NotFoundException
+     * @throws ForbiddenException
+     * @throws UnauthorizedException
+     * @throws ServerException
+     *
      */
     public String obtainGitHubToken(String keycloakToken) throws ServerException, UnauthorizedException, ForbiddenException, NotFoundException, ConflictException, BadRequestException, IOException {
         String responseBody = getResponseBody(gitHubEndpoint, keycloakToken);
@@ -77,29 +77,33 @@ public class KeycloakTokenProvider {
 
     /**
      * Return OpenShift online token based on Keycloak token
-     * 
+     *
      * <p>
-     * Note: valid response from keycloak endpoint: 
+     * Note: valid response from keycloak endpoint:
      *       {"access_token":"token","expires_in":86400,"scope":"user:full","token_type":"Bearer"}
      * </p>
-     * 
+     *
      * @param  keycloakToken
-     * 
-     * @return OpenShift online token 
-     * @throws BadRequestException 
-     * @throws ConflictException 
-     * @throws NotFoundException 
-     * @throws ForbiddenException 
-     * @throws UnauthorizedException 
-     * @throws ServerException 
-     * 
+     *
+     * @return OpenShift online token
+     * @throws BadRequestException
+     * @throws ConflictException
+     * @throws NotFoundException
+     * @throws ForbiddenException
+     * @throws UnauthorizedException
+     * @throws ServerException
+     *
      */
     public String obtainOsoToken(String keycloakToken) throws IOException, ServerException, UnauthorizedException, ForbiddenException, NotFoundException, ConflictException, BadRequestException {
         String responseBody = getResponseBody(openShiftEndpoint, keycloakToken);
         ObjectMapper mapper = new ObjectMapper();
         JsonNode json = mapper.readTree(responseBody);
         JsonNode token = json.get(ACCESS_TOKEN);
-        return token.asText();
+        if (token != null) {
+            return token.asText();
+        } else {
+            return null;
+        }
     }
 
     private String getResponseBody(final String endpoint, final String keycloakToken) throws ServerException, UnauthorizedException, ForbiddenException, NotFoundException, ConflictException, BadRequestException, IOException {

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/util/KeycloakUserValidator.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/util/KeycloakUserValidator.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat inc.
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package com.redhat.che.keycloak.token.provider.util;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.redhat.che.keycloak.token.provider.service.KeycloakTokenProvider;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+
+/**
+ * Validates that a user, specified by a keycloak token, matches the user that
+ * owns the OpenShift namespace where this class is loaded.
+ *
+ * @author amisevsk
+ */
+@Singleton
+public final class KeycloakUserValidator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakUserValidator.class);
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final int CACHE_TIMEOUT_MINUTES = 10;
+
+    private final KeycloakTokenProvider keycloakTokenProvider;
+
+    /**
+     * Cache that stores mappings from keycloak token to OpenShift token. Timeout is
+     * equal to CACHE_TIMEOUT_MINUTES.
+     *
+     * @see TokenLoader
+     */
+    private final LoadingCache<String, String> keycloakToOpenshiftTokenCache;
+
+    /**
+     * Cache that stores mappings from OpenShift tokens to Users. Timeout is equal to
+     * CACHE_TIMEOUT_MINUTES.
+     *
+     * @see UserLoader
+     */
+    private final LoadingCache<String, String> openShiftTokenToUserCache;
+
+    @Inject
+    public KeycloakUserValidator(KeycloakTokenProvider tokenProvider) {
+        this.keycloakTokenProvider = tokenProvider;
+
+        this.keycloakToOpenshiftTokenCache = CacheBuilder.newBuilder()
+                                                         .maximumSize(100)
+                                                         .expireAfterWrite(CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                                                         .build(new TokenLoader());
+        this.openShiftTokenToUserCache = CacheBuilder.newBuilder()
+                                                     .maximumSize(100)
+                                                     .expireAfterWrite(CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                                                     .build(new UserLoader());
+    }
+
+    /**
+     * Check if user specified by keycloak token matches the user associated with the current
+     * Che instance by making request against the relevant endpoints. To improve performance,
+     * API responses are cached for a period of time.
+     *
+     * @param keycloakToken the value of the auth header (i.e. the keycloak token)
+     * @return true if the user is authorized to access this instance of Che, false otherwise.
+     */
+    public boolean matchesUsername(String keycloakToken) {
+
+        if (isNullOrEmpty(keycloakToken)) {
+            LOG.info("Received request with null or empty auth value. Returning false");
+            return false;
+        }
+
+        String openShiftToken = "";
+        try {
+            openShiftToken = getOpenShiftToken(keycloakToken);
+        } catch (ServerException | UnauthorizedException | ForbiddenException | NotFoundException | ConflictException
+                | BadRequestException | IOException e) {
+            LOG.error("Could not get OpenShift token due to exception: {}", e.getMessage());
+        }
+        if (isNullOrEmpty(openShiftToken)) {
+            return false;
+        }
+        String openShiftUser = getOpenShiftUser(openShiftToken);
+        if (isNullOrEmpty(openShiftUser)) {
+            return false;
+        }
+        return openShiftUser.equals(getOpenShiftProjectOwner());
+    }
+
+    /**
+     * Get the OpenShift token associated with a particular Keycloak token.
+     * @param keycloakToken the Keycloak token
+     * @return the OpenShift token
+     * @throws ServerException
+     * @throws UnauthorizedException
+     * @throws ForbiddenException
+     * @throws NotFoundException
+     * @throws ConflictException
+     * @throws BadRequestException
+     * @throws IOException
+     *
+     * @see TokenLoader
+     */
+    private String getOpenShiftToken(String keycloakToken) throws ServerException, UnauthorizedException,
+            ForbiddenException, NotFoundException, ConflictException, BadRequestException, IOException {
+        try {
+            // Ensure header has "Bearer:" prefix
+            String auth = keycloakToken.startsWith("Bearer") ? keycloakToken : "Bearer " + keycloakToken;
+            String openShiftToken = keycloakToOpenshiftTokenCache.get(auth);
+            return openShiftToken;
+        } catch (ExecutionException e) {
+            LOG.error("Exception while getting OpenShift token: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Gets the OpenShift user associated with an OpenShift token.
+     * @param openShiftToken The OpenShift token
+     * @return
+     *
+     * @see UserLoader
+     */
+    private String getOpenShiftUser(String openShiftToken) {
+        try {
+            String currentUsername = openShiftTokenToUserCache.get(openShiftToken);
+            if (currentUsername.contains("@")) {
+                // Some usernames are email addresses
+                currentUsername = currentUsername.split("@")[0];
+            }
+            return currentUsername;
+        } catch (ExecutionException e) {
+            LOG.error("Exception while getting user: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Get the owner of the current OpenShift namespace. Note that usernames may, in some cases,
+     * be email addresses.
+     * @return the username, as specified by OpenShift
+     */
+    private String getOpenShiftProjectOwner() {
+        try(OpenShiftClient client = new DefaultOpenShiftClient()) {
+            String namespace = client.getNamespace().split("-")[0];
+            return namespace;
+        }
+    }
+
+    /**
+     * Load openshift tokens, given keycloak tokens. If an error occurs, loads the
+     * empty string.
+     *
+     * @see CacheLoader
+     */
+    private class TokenLoader extends CacheLoader<String, String> {
+
+        @Override
+        public String load(String keycloakToken) {
+            String osoToken = null;
+            try {
+                osoToken = keycloakTokenProvider.obtainOsoToken(keycloakToken);
+            } catch (ServerException | UnauthorizedException | ForbiddenException | NotFoundException
+                    | ConflictException | BadRequestException | IOException e) {
+                LOG.error("Exception while obtaining OSO token: {}", e.getMessage());
+            }
+            return osoToken != null ? osoToken : "";
+        }
+    }
+
+    /**
+     * Load OpenShift username, given a OpenShift token. In case of error, the empty
+     * string is returned.
+     *
+     * @see CacheLoader
+     */
+    private class UserLoader extends CacheLoader<String, String> {
+
+        @Override
+        public String load(String token) {
+            OpenShiftConfig openShiftConfig = new OpenShiftConfigBuilder().withOauthToken(token).build();
+            try (OpenShiftClient client = new DefaultOpenShiftClient(openShiftConfig)) {
+                String username = client.currentUser().getMetadata().getName();
+                return username;
+            } catch (KubernetesClientException e) {
+                LOG.error("Exception while getting username: {}", e.getMessage());
+                return "";
+            }
+        }
+    }
+}

--- a/builds/fabric8-che/pom.xml
+++ b/builds/fabric8-che/pom.xml
@@ -94,10 +94,16 @@
                 <version>${redhat.che.version}</version>
                 <type>war</type>
             </dependency>
-           <dependency>
+            <dependency>
                 <groupId>com.redhat.che</groupId>
                 <artifactId>ls-bayesian-agent</artifactId>
                 <version>${rh.che.plugins.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.che</groupId>
+                <artifactId>user-auth-valve</artifactId>
+                <version>@redhat.che.version@</version>
                 <type>jar</type>
             </dependency>
             <dependency>
@@ -136,6 +142,11 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-servlet-filter-adapter</artifactId>
+                <version>${keycloak.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-tomcat8-adapter</artifactId>
                 <version>${keycloak.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Adds functionality to our Keycloak integration to also check which user is associated with a provided keycloak token, and blocks access to Che if that user is not the owner of the namespace in which Che is deployed

Changes:
- Add endpoint `/api/token/user`, which returns true if the token provided in the authorization header corresponds to the user who owns the namespace.
- Implement an extension of `KeycloakAuthenticatorValve` to perform this check using the above endpoint
- Update `KeycloakAuthenticationFilter` to do the same
- Testing Che locally is no longer possible with keycloak enabled, as keycloak integration now depends on external keycloak server for OSO tokens, which won't match local OSO tokens.

These changes don't include any updates to restrict access to the dashboard war (I couldn't figure out a straightforward way to implement this, but also didn't look too hard). As a result, forbidden users get stuck on a loading screen when trying to access the dashboard. The updated valve does block access to workspaces, however.

I consider this a first pass at including this functionality in keycloak, so suggestions for improvement are *very* welcome.

Fixes issue #139.