### PR TITLE
CHE-283 : Add a property to disable keycloak authentication in rh-che assembly

### DIFF
--- a/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/IDE.jsp.patch
+++ b/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/IDE.jsp.patch
@@ -2,7 +2,7 @@
 +++ src/main/webapp/IDE.jsp
 @@ -55,7 +55,37 @@
          };
- 
+
      </script>
 +  <script type="text/javascript" language="javascript" src="/_app/keycloak/keycloak.js"></script>
 +  <script>

--- a/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/IDE.jsp.patch
+++ b/builds/fabric8-che/assembly/assembly-ide-war/src/main/patches/src/main/webapp/IDE.jsp.patch
@@ -1,32 +1,39 @@
 --- src/main/webapp/IDE.jsp
 +++ src/main/webapp/IDE.jsp
-@@ -55,7 +55,30 @@
+@@ -55,7 +55,37 @@
          };
-
+ 
      </script>
 +  <script type="text/javascript" language="javascript" src="/_app/keycloak/keycloak.js"></script>
 +  <script>
-+    window.keycloak = Keycloak({
-+      url: 'https://sso.openshift.io/auth',
-+      realm: 'fabric8',
-+      clientId: 'openshiftio-public',
-+    });
-+    window.keycloak.init({ onLoad: 'check-sso', checkLoginIframe: false, }).success(function(authenticated) {
-+       console.log('IDE.jsp authenticated with token:'+ window.keycloak.token);
-+    }).error(function() {
-+       console.log('failed to initialize');
-+    });
-
-+    // Until there's a synchronous way to call updateToken from within gwt (it's currently
-+    // asynchronous), just attempt to refresh it every 5 mins.
-+    setInterval(function() { window.keycloak.updateToken()
-+        .success(function(refreshed){
-+            console.log('IDE.js token.refresh :'+refreshed);
-+            if(refreshed){
-+                console.log('IDE.js setting token to'+ window.keycloak.token);
-+            }
-+        })
-+        ; }, 300000);
++    const req = new XMLHttpRequest();
++    req.open('GET', window.IDE.config['restContext'] + '/keycloak/settings', false);
++    req.send(null); console.log('responseText = ' + req.responseText);
++    const keycloakDisabled = JSON.parse(req.responseText);
++    if (keycloakDisabled['che.keycloak.disabled'] != "true") {
++          window.keycloak = Keycloak({
++              url: 'https://sso.openshift.io/auth',
++              realm: 'fabric8',
++              clientId: 'openshiftio-public',
++            });
++            window.keycloak.init({ onLoad: 'check-sso', checkLoginIframe: false, }).success(function(authenticated) {
++               console.log('IDE.jsp authenticated with token:'+ window.keycloak.token);
++            }).error(function() {
++               console.log('failed to initialize');
++            });
+ 
++            // Until there's a synchronous way to call updateToken from within gwt (it's currently
++            // asynchronous), just attempt to refresh it every 5 mins.
++            setInterval(function() { window.keycloak.updateToken()
++                .success(function(refreshed){
++                    console.log('IDE.js token.refresh :'+refreshed);
++                    if(refreshed){
++                        console.log('IDE.js setting token to'+ window.keycloak.token);
++                    }
++                })
++                ; }, 300000);
++    }
++  
 +  </script>
      <script type="text/javascript" language="javascript" src="/_app/browserNotSupported.js"></script>
      <script type="text/javascript" language="javascript" async="true" src="/_app/_app.nocache.js"></script>

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/pom.xml
@@ -66,6 +66,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <warSourceDirectory>${project.build.directory}/patched/src/main/webapp</warSourceDirectory>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <dependentWarIncludes>**,META-INF/context.xml,WEB-INF/**</dependentWarIncludes>
+                    <dependentWarExcludes>META-INF/MANIFEST.MF,META-INF/maven/**,WEB-INF/lib/che-plugin-svn-ext-*,WEB-INF/classes/org/eclipse/che/wsagent/server/CheWsAgentServletModule.class</dependentWarExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
@@ -10,17 +10,21 @@
  *******************************************************************************/
 package org.eclipse.che.wsagent.server;
 
-import com.google.inject.servlet.ServletModule;
+import javax.inject.Singleton;
 
 import org.eclipse.che.inject.DynaModule;
+
+import com.google.inject.name.Names;
+import com.google.inject.servlet.ServletModule;
 import com.redhat.che.keycloak.server.KeycloakAuthenticationFilter;
-import javax.inject.Singleton;
+import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
 
 /** @author andrew00x */
 @DynaModule
 public class RedHatCheWsAgentServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
+        bind(Boolean.class).annotatedWith(Names.named("che.keycloak.disabled")).toProvider(KeycloakPropertiesProvider.class);
         bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
         filter("/*").through(KeycloakAuthenticationFilter.class);
     }

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
@@ -12,7 +12,9 @@ package org.eclipse.che.wsagent.server;
 
 import javax.inject.Singleton;
 
+import org.eclipse.che.api.core.cors.CheCorsFilter;
 import org.eclipse.che.inject.DynaModule;
+import org.everrest.guice.servlet.GuiceEverrestServlet;
 
 import com.google.inject.name.Names;
 import com.google.inject.servlet.ServletModule;
@@ -24,6 +26,9 @@ import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
 public class RedHatCheWsAgentServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
+        filter("/*").through(CheCorsFilter.class);
+        serveRegex("^/api((?!(/(ws|eventbus)($|/.*)))/.*)").with(GuiceEverrestServlet.class);
+        
         bind(Boolean.class).annotatedWith(Names.named("che.keycloak.disabled")).toProvider(KeycloakPropertiesProvider.class);
         bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
         filter("/*").through(KeycloakAuthenticationFilter.class);

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/RedHatCheWsAgentServletModule.java
@@ -10,16 +10,15 @@
  *******************************************************************************/
 package org.eclipse.che.wsagent.server;
 
-import javax.inject.Singleton;
-
-import org.eclipse.che.api.core.cors.CheCorsFilter;
-import org.eclipse.che.inject.DynaModule;
-import org.everrest.guice.servlet.GuiceEverrestServlet;
-
-import com.google.inject.name.Names;
 import com.google.inject.servlet.ServletModule;
+
+import org.eclipse.che.inject.DynaModule;
 import com.redhat.che.keycloak.server.KeycloakAuthenticationFilter;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.cors.CheCorsFilter;
 import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
+import org.everrest.guice.servlet.GuiceEverrestServlet;
+import com.google.inject.name.Names;
 
 /** @author andrew00x */
 @DynaModule

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -12,17 +12,17 @@ package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.name.Names;
 import com.redhat.che.keycloak.server.KeycloakHttpJsonRequestFactory;
-import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
 
-import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.inject.DynaModule;
 
+import com.google.inject.name.Names;
 import java.net.URI;
+import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
+import org.eclipse.che.UriApiEndpointProvider;
 
 import javax.inject.Named;
 

--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -12,13 +12,17 @@ package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.name.Names;
 import com.redhat.che.keycloak.server.KeycloakHttpJsonRequestFactory;
+import com.redhat.che.keycloak.server.KeycloakPropertiesProvider;
 
+import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.inject.DynaModule;
 
+import java.net.URI;
 
 import javax.inject.Named;
 
@@ -46,8 +50,8 @@ public class WsAgentModule extends AbstractModule {
         install(new org.eclipse.che.api.core.jsonrpc.impl.JsonRpcModule());
         install(new org.eclipse.che.api.core.websocket.impl.WebSocketModule());
 
+        bind(Boolean.class).annotatedWith(Names.named("che.keycloak.disabled")).toProvider(KeycloakPropertiesProvider.class);
         bind(HttpJsonRequestFactory.class).to(KeycloakHttpJsonRequestFactory.class);
-
     }
 
     //it's need for WSocketEventBusClient and in the future will be replaced with the property

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -234,5 +234,6 @@ public class WsMasterModule extends AbstractModule {
 
         Multibinder<OAuthAuthenticator> oAuthAuthenticators = Multibinder.newSetBinder(binder(), OAuthAuthenticator.class);
         oAuthAuthenticators.addBinding().to(OpenShiftGitHubOAuthAuthenticator.class);
+        bind(com.redhat.che.keycloak.server.KeycloakService.class);
     }
 }

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
@@ -2,3 +2,5 @@
 # Endpoints for obtiaining Github / OpenShift Online tokens based on Keycloak token
 che.keycloak.oso.endpoint=NULL
 che.keycloak.github.endpoint=NULL
+
+che.keycloak.disabled=false

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
@@ -3,4 +3,4 @@
 che.keycloak.oso.endpoint=NULL
 che.keycloak.github.endpoint=NULL
 
-che.keycloak.disabled=false
+che.keycloak.disabled=true

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/rh-che.properties
@@ -2,5 +2,4 @@
 # Endpoints for obtiaining Github / OpenShift Online tokens based on Keycloak token
 che.keycloak.oso.endpoint=NULL
 che.keycloak.github.endpoint=NULL
-
 che.keycloak.disabled=true

--- a/builds/fabric8-che/assembly/dashboard/src/main/patches/src/app/index.module.ts.patch
+++ b/builds/fabric8-che/assembly/dashboard/src/main/patches/src/app/index.module.ts.patch
@@ -60,7 +60,7 @@
  
  // add a global resolve flag on all routes (user needs to be resolved first)
  initModule.config(['$routeProvider', ($routeProvider) => {
-@@ -165,6 +211,42 @@
+@@ -168,6 +214,44 @@
      });
    }]);
  
@@ -77,7 +77,7 @@
 +        let deferred = $q.defer();
 +        keycloak.updateToken(5).success(function () {
 +          config.headers = config.headers || {};
-+          config.headers.Authorization = 'Bearer ' + keycloak.token;
++          angular.extend(config.headers, {'Authorization': 'Bearer ' + keycloak.token});
 +          console.log('injecting token : ' + config.url);
 +          deferred.resolve(config);
 +        }).error(function () {
@@ -91,19 +91,21 @@
 +    response: (response) => {
 +      console.log('RESPONSE '+response.config.url+ ' :' + JSON.stringify(response));
 +      return response || $q.when(response);
-+    },responseError: (rejection)=>{
++    },
++    responseError: (rejection)=>{
 +        console.log('ERROR (response) : '+ JSON.stringify(rejection));
++        return $q.reject(rejection);
 +    },
 +    requestError: (rejection) =>{
-+       console.log('ERROR (request) : '+ JSON.stringify(rejection))
++       console.log('ERROR (request) : '+ JSON.stringify(rejection));
++       return $q.reject(rejection);
 +    }
-+
 +  }
 +});
  
  // add interceptors
  initModule.factory('ETagInterceptor', ($window, $cookies, $q) => {
-@@ -355,6 +437,7 @@
+@@ -358,6 +442,7 @@
  });
  
  initModule.config(['$routeProvider', '$locationProvider', '$httpProvider', ($routeProvider, $locationProvider, $httpProvider) => {

--- a/builds/fabric8-che/assembly/dashboard/src/main/patches/src/app/index.module.ts.patch
+++ b/builds/fabric8-che/assembly/dashboard/src/main/patches/src/app/index.module.ts.patch
@@ -1,6 +1,6 @@
 --- src/app/index.module.ts
 +++ src/app/index.module.ts
-@@ -31,13 +31,36 @@ import {ProxySettingsConfig} from './proxy/proxy-settings.constant';
+@@ -31,13 +31,59 @@
  import {WorkspacesConfig} from './workspaces/workspaces-config';
  import {StacksConfig} from './stacks/stacks-config';
  import {DemoComponentsCtrl} from './demo-components/demo-components.controller';
@@ -17,27 +17,50 @@
    'angular-websocket', 'ui.bootstrap', 'ui.codemirror', 'ngMaterial', 'ngMessages', 'angularMoment', 'angular.filter',
    'ngDropdowns', 'ngLodash', 'angularCharts', 'ngClipboard', 'uuid4', 'angularFileUpload']);
  
-+angular.element(document).ready(() => {
++angular.element(document).ready(($injector) => {
++
++  let promise = $injector.get('../wsmaster/api/keycloak/settings');
++
++  function keycloakInit(keycloakDisabled) {
++      if (keycloakDisabled) {
++        window['_keycloak'] = false;
++        angular.bootstrap(document, ['userDashboard'], {strictDi:true}); // manually bootstrap Angular
++      } else {
++        window['_keycloak'] = Keycloak(keycloakConfig);
++        window['_keycloak']
++          .init({
++            onLoad: 'login-required'
++          })
++          .success(() => {
++            angular.bootstrap(document, ['userDashboard'], {strictDi:true}); // manually bootstrap Angular
++          });
++      }
++    
++  }
++
++  promise.then((resp) => {
++    console.log('resp : ' + resp.toString() );
++    if (resp['che.keycloak.disabled'] == 'true') {
++      keycloakInit(true);
++    } else {
++      keycloakInit(false);
++    }
++  }, (error) => {
++    console.log(error);
++    keycloakInit(false);
++  });
++  
 +  console.log('running keycloak init sequence');
 +
-+  window['_keycloak'] = Keycloak(keycloakConfig);
-+
-+  window['_keycloak']
-+    .init({
-+      onLoad: 'login-required'
-+    })
-+    .success(() => {
-+      angular.bootstrap(document, ['userDashboard'], {strictDi:true}); // manually bootstrap Angular
-+    });
 +});
 +
 +initModule.factory('keycloak', $window => {
-+  return $window._keycloak;
++    return $window._keycloak;
 +});
  
  // add a global resolve flag on all routes (user needs to be resolved first)
  initModule.config(['$routeProvider', ($routeProvider) => {
-@@ -165,6 +188,42 @@ initModule.run(['$rootScope', '$location', '$routeParams', 'routingRedirect', '$
+@@ -165,6 +211,42 @@
      });
    }]);
  
@@ -80,7 +103,7 @@
  
  // add interceptors
  initModule.factory('ETagInterceptor', ($window, $cookies, $q) => {
-@@ -355,6 +414,7 @@ initModule.constant('userDashboardConfig', {
+@@ -355,6 +437,7 @@
  });
  
  initModule.config(['$routeProvider', '$locationProvider', '$httpProvider', ($routeProvider, $locationProvider, $httpProvider) => {

--- a/builds/fabric8-che/plugins/keycloak-plugin-ide/src/main/java/com/redhat/che/keycloak/ide/KeycloakAsyncRequestFactory.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-ide/src/main/java/com/redhat/che/keycloak/ide/KeycloakAsyncRequestFactory.java
@@ -8,7 +8,6 @@ import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.rest.AsyncRequest;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
 import org.eclipse.che.ide.rest.HTTPHeader;
-
 import com.google.common.base.Preconditions;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.inject.Inject;
@@ -41,7 +40,6 @@ public class KeycloakAsyncRequestFactory extends AsyncRequestFactory {
         }
 
         AsyncRequest asyncRequest = new KeycloakAsyncRequest(method, url, async);
-        
         if (dtoBody != null) {
             if (dtoBody instanceof List) {
                 asyncRequest.data(dtoFactory.toJson((List)dtoBody));
@@ -68,7 +66,7 @@ public class KeycloakAsyncRequestFactory extends AsyncRequestFactory {
         return asyncRequest;
     }
 
-    public static native String getBearerToken() /*-{
+      public static native String getBearerToken() /*-{
         //$wnd.keycloak.updateToken(10);
         return "Bearer " + $wnd.keycloak.token;
     }-*/;

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src-without-keycloak/main/java/com/redhat/che/keycloak/server/KeycloakService.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src-without-keycloak/main/java/com/redhat/che/keycloak/server/KeycloakService.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.che.keycloak.server;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.che.api.core.rest.Service;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Defines Keycloak REST API.
+ *
+ * @author David Festal
+ */
+@Path("/keycloak")
+public class KeycloakService extends Service {
+
+    private final boolean                       keycloakDisabled;
+
+    @Inject
+    public KeycloakService(@Named("che.keycloak.disabled") boolean keycloakDisabled) {
+        this.keycloakDisabled = keycloakDisabled;
+    }
+
+    @GET
+    @Path("/settings")
+    @Produces(APPLICATION_JSON)
+    public Map<String, String> disabled() {
+        return ImmutableMap.of("che.keycloak.disabled", Boolean.toString(keycloakDisabled));
+    }
+}

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakHttpJsonRequestFactory.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakHttpJsonRequestFactory.java
@@ -12,6 +12,7 @@
 package com.redhat.che.keycloak.server;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 
@@ -22,17 +23,26 @@ import org.eclipse.che.api.core.rest.shared.dto.Link;
 @Singleton
 public class KeycloakHttpJsonRequestFactory extends DefaultHttpJsonRequestFactory {
 
+    private boolean keycloakDisabled;
+
     @Inject
-    public KeycloakHttpJsonRequestFactory() {
+    public KeycloakHttpJsonRequestFactory(@Named("che.keycloak.disabled") boolean keycloakDisabled) {
+        this.keycloakDisabled = keycloakDisabled;
     }
 
     @Override
     public HttpJsonRequest fromUrl(@NotNull String url) {
+        if (keycloakDisabled) {
+            return super.fromUrl(url);
+        }
         return super.fromUrl(url).setAuthorizationHeader("Internal");
     }
 
     @Override
     public HttpJsonRequest fromLink(@NotNull Link link) {
+        if (keycloakDisabled) {
+            return super.fromLink(link);
+        }
         return super.fromLink(link).setAuthorizationHeader("Internal");
     }
 

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakPropertiesProvider.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakPropertiesProvider.java
@@ -1,0 +1,74 @@
+package com.redhat.che.keycloak.server;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.api.core.rest.DefaultHttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Injects DNS resolvers and ensures that it is neither empty array nor single value array with null or empty string.
+ *
+ * @author Alexander Garagatyi
+ */
+@Singleton
+public class KeycloakPropertiesProvider implements Provider<Boolean> {
+    private String keycloakSettingsEnpoint;
+    private Boolean keycloakDisabled = Boolean.FALSE;
+    private boolean keycloakDisabledRetrieved = false;
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakPropertiesProvider.class);
+
+    class LocalHttpJsonRequest extends DefaultHttpJsonRequest {
+        public LocalHttpJsonRequest(String url) {
+            super(url);
+        }
+    }
+
+    @Inject
+    public KeycloakPropertiesProvider(@Named("che.api") String apiEndpoint) {
+        keycloakSettingsEnpoint = apiEndpoint.concat("/keycloak/settings");
+        LOG.info("Endpoint = " + keycloakSettingsEnpoint);
+        retrieveKeycloakDisabled();
+    }
+
+    private void retrieveKeycloakDisabled() {
+        if (! keycloakDisabledRetrieved) {
+            LOG.info("Submitting request...");
+            HttpJsonRequest req = new LocalHttpJsonRequest(keycloakSettingsEnpoint);
+            try {
+                HttpJsonResponse resp = req.request();
+                String respAsString = resp.asString();
+                LOG.info("  => Response = " + respAsString);
+                String disabledSetting = req.request().asProperties().get("che.keycloak.disabled");
+                LOG.info("    => Disabled = " + disabledSetting);
+                keycloakDisabled = "true".equals(disabledSetting);
+                LOG.info("Pproperty 'che.keycloak.disabled' ==> " + keycloakDisabled);
+                keycloakDisabledRetrieved = true;
+            } catch (ServerException 
+                | UnauthorizedException | ForbiddenException
+                | NotFoundException | ConflictException
+                | BadRequestException | IOException e) {
+                LOG.error("Error while retrieving the Keycloak enablement property", e);
+            }
+        }
+    }
+
+    @Override
+    public Boolean get() {
+        retrieveKeycloakDisabled();
+        return keycloakDisabled;
+    }
+}

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakService.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakService.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.che.keycloak.server;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.che.api.core.rest.Service;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Defines Keycloak REST API.
+ *
+ * @author David Festal
+ */
+@Path("/keycloak")
+public class KeycloakService extends Service {
+
+    private final boolean                       keycloakDisabled;
+
+    @Inject
+    public KeycloakService(@Named("che.keycloak.disabled") boolean keycloakDisabled) {
+        this.keycloakDisabled = keycloakDisabled;
+    }
+
+    @GET
+    @Path("/settings")
+    @Produces(APPLICATION_JSON)
+    public Map<String, String> disabled() {
+        return ImmutableMap.of("che.keycloak.disabled", Boolean.toString(keycloakDisabled));
+    }
+}


### PR DESCRIPTION
This PR introduces the new `che.keycloak.disabled` property in the `rh-che.properties` file.

When this property is set to `true`, all the related Keycloak actions, both client side and server-side are bypassed, and no authentication is required.
