### PR TITLE
Revert "Skip functional test in CI because they are broken"

### DIFF
--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -16,14 +16,13 @@ echo "export CHE_SERVER_DOCKER_IMAGE_TAG=$CHE_SERVER_DOCKER_IMAGE_TAG" >> $confi
 echo "export DOCKER_HUB_NAMESPACE=${DOCKER_HUB_NAMESPACE}" >> $config_file
 
 # Triggers update of tenant and execution of functional tests
-echo "CHE VALIDATION: Verification skipped until job devtools-che-functional-tests get fixed"
-# git clone https://github.com/redhat-developer/che-functional-tests.git
-# mv $config_file che-functional-tests/config
-# cp jenkins-env che-functional-tests/jenkins-env
-# cd che-functional-tests
-# . cico_run_EE_tests.sh
+git clone https://github.com/redhat-developer/che-functional-tests.git
+mv $config_file che-functional-tests/config
+cp jenkins-env che-functional-tests/jenkins-env
+cd che-functional-tests
+. cico_run_EE_tests.sh
 
-# echo "CHE VALIDATION: Verification passed. Pushing Che server image to prod registry."
+echo "CHE VALIDATION: Verification passed. Pushing Che server image to prod registry."
 docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_PASSWORD} -e noreply@redhat.com
 docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG} rhche/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}
 docker push rhche/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}


### PR DESCRIPTION
Reverts redhat-developer/rh-che#171, tests now should run successfuly