### PR TITLE
Keycloak Authentication fails when username contains a dot (#183)

### DIFF
--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/util/OpenShiftUserToProjectNameConverter.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/util/OpenShiftUserToProjectNameConverter.java
@@ -1,0 +1,41 @@
+package com.redhat.che.keycloak.token.provider.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for extracting name used for project on OpenShift.io
+ * from a given OpenShift username.
+ *
+ * <p> The name used to define OpenShift projects must be converted before
+ * being used as a project name due to different limitations on format between
+ * the two.
+ */
+public class OpenShiftUserToProjectNameConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenShiftUserToProjectNameConverter.class);
+
+    /**
+     * Gets expected project name from an OpenShift username. Currently, usernames are converted
+     * using
+     * <li> all characters after an {@code '@'} character (e.g. in an email) are stripped off, including {@code '@'}
+     * <li> {@code '.'} characters are converted into {@code '-'}
+     * <li> if a username contains a {@code '+'} character, it should also be converted to {@code '-'}
+     *
+     * @param openShiftUsername The openshift username
+     * @return the expected project name
+     */
+    public static String getProjectNameFromUsername(String openShiftUsername) {
+        String projectName = openShiftUsername;
+        LOG.debug("Getting project name from openshift user: {}", projectName);
+        if (projectName.contains("@")) {
+            // Username is an email address
+            projectName = projectName.split("@")[0];
+        }
+        projectName = projectName.replaceAll("\\.", "-");
+        projectName = projectName.replaceAll("\\+", "-");
+
+        LOG.debug("Got project name: {}", projectName);
+        return projectName;
+    }
+}

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/test/java/com/redhat/che/keycloak/token/provider/util/OpenShiftUserToProjectNameConverterTest.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-provider/src/test/java/com/redhat/che/keycloak/token/provider/util/OpenShiftUserToProjectNameConverterTest.java
@@ -1,0 +1,46 @@
+package com.redhat.che.keycloak.token.provider.util;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class OpenShiftUserToProjectNameConverterTest {
+
+    @Test
+    public void shouldStripEmailDomainFromUsername() {
+        // Given
+        String usernameWithEmail = "testuser@domain.com";
+        String expected = "testuser";
+
+        // When
+        String actual = OpenShiftUserToProjectNameConverter.getProjectNameFromUsername(usernameWithEmail);
+
+        // Then
+        assertEquals("Should remove @domain from username", expected, actual);
+    }
+
+    @Test
+    public void shouldConvertDotsToDashesInUsername() {
+        // Given
+        String usernameWithDot = "test.user";
+        String expected = "test-user";
+
+        // When
+        String actual = OpenShiftUserToProjectNameConverter.getProjectNameFromUsername(usernameWithDot);
+
+        // Then
+        assertEquals("Should convert '.' to '-' in username", expected, actual);
+    }
+
+    @Test
+    public void shouldConvertDotsAndStripEmail() {
+        // Given
+        String username = "test.user@domain.com";
+        String expected = "test-user";
+
+        // When
+        String actual = OpenShiftUserToProjectNameConverter.getProjectNameFromUsername(username);
+
+        // Then
+        assertEquals("Should convert '.' to '-' in username and strip email", expected, actual);
+    }
+}


### PR DESCRIPTION
Fix issue relating to OSIO translation between OS username and OS project name.

- Improves KeycloakUserValidator to support extracting project name from namespace when namespace contains multiple '-' chars (e.g. project-name-che -> project-name)
- Adds OpenShiftUserToProjectNameConverter class to consolidate conversion between username -> project name in one place. Currently, the required changes are 1) stripping @domain.com from usernames (when they are email addresses) and 2) replacing `'.'` with `'-'` in usernames. 

Additionally, I have it so that `'+'` in a username is replaced by `'-'`. This is done when creating users on RHD, so it should not be necessary here, but it's safer to include it now, since testing it is hard without many OSIO accounts. 

Fixes: #183 