### PR TITLE
Adding a new label: severity/low-priority

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -60,6 +60,10 @@
     "color": "#cccccc"
   },
   {
+    "name": "severity/low-priority",
+    "color": "#fef2c0"
+  },
+  {
     "name": "sprint/current-sprint",
     "color": "#FFFFFF"
   },


### PR DESCRIPTION
Adding `severity/low-priority` label for this repo. Issues and enhancements that are labelled low-priority should not be taken in consideration for current sprint or next sprint.