### PR TITLE
Inject keycloak user token to bayesian LS

### DIFF
--- a/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/builds/fabric8-che/assembly/assembly-wsagent-war/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -25,6 +25,7 @@ import com.redhat.che.keycloak.server.KeycloakClientIdPropertyProvider;
 import com.redhat.che.keycloak.server.KeycloakDisabledPropertyProvider;
 import com.redhat.che.keycloak.server.KeycloakRealmPropertyProvider;
 import com.redhat.che.keycloak.shared.KeycloakConstants;
+import com.redhat.che.keycloak.token.store.service.KeycloakTokenStore;
 
 import javax.inject.Named;
 
@@ -57,6 +58,7 @@ public class WsAgentModule extends AbstractModule {
         bind(String.class).annotatedWith(Names.named(KeycloakConstants.CLIENT_ID_SETTING)).toProvider(KeycloakClientIdPropertyProvider.class);
         bind(String.class).annotatedWith(Names.named(KeycloakConstants.REALM_SETTING)).toProvider(KeycloakRealmPropertyProvider.class);
         bind(HttpJsonRequestFactory.class).to(KeycloakHttpJsonRequestFactory.class);
+        bind(KeycloakTokenStore.class);
     }
 
     //it's need for WSocketEventBusClient and in the future will be replaced with the property

--- a/builds/fabric8-che/plugins/che-plugin-bayesian-lang-server/pom.xml
+++ b/builds/fabric8-che/plugins/che-plugin-bayesian-lang-server/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.redhat.che</groupId>
+            <artifactId>che-keycloak-plugin-token-store</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-languageserver</artifactId>
         </dependency>

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/pom.xml
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>che-keycloak-plugin-shared</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.redhat.che</groupId>
+            <artifactId>che-keycloak-plugin-token-store</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.redhat.che.keycloak.server.oso.service.account.ServiceAccountInfoProvider;
 import com.redhat.che.keycloak.shared.KeycloakConstants;
+import com.redhat.che.keycloak.token.store.service.KeycloakTokenStore;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -40,6 +41,9 @@ public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
 
     private boolean keycloakDisabled;
+
+    @Inject
+    private KeycloakTokenStore kcTokenStore;
 
     @Inject
     private KeycloakUserChecker userChecker;
@@ -80,6 +84,7 @@ public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.
         } else if (userChecker.matchesUsername(authHeader)) {
             super.doFilter(req, res, chain);
             LOG.debug("{} status : {}", request.getRequestURL(), ((HttpServletResponse) res).getStatus());
+            kcTokenStore.setLastToken(authHeader);
         } else {
             HttpServletResponse response = (HttpServletResponse) res;
             response.sendError(403);

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakAuthenticationFilter.java
@@ -142,7 +142,7 @@ public class KeycloakAuthenticationFilter extends org.keycloak.adapters.servlet.
     private boolean isWebsocketRequest(String requestURI, String requestScheme, String upgradeHeader) {
         return "websocket".equals(upgradeHeader) && //
                (requestURI.endsWith("/ws") || requestURI.endsWith("/eventbus") || requestScheme.equals("ws") || requestScheme.equals("wss")
-                || requestURI.contains("/websocket") || requestURI.contains("/wsagent"));
+                || requestURI.contains("/websocket") || requestURI.endsWith("/wsagent"));
     }
 
     /**

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-store/pom.xml
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-store/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat - Initial Contribution
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>fabric8-ide-plugins-parent</artifactId>
+        <groupId>com.redhat.che</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <groupId>com.redhat.che</groupId>
+    <artifactId>che-keycloak-plugin-token-store</artifactId>
+    <name>Che Keycloak Token Store plugin</name>
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/builds/fabric8-che/plugins/keycloak-plugin-token-store/src/main/java/com/redhat/che/keycloak/token/store/service/KeycloakTokenStore.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-token-store/src/main/java/com/redhat/che/keycloak/token/store/service/KeycloakTokenStore.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+package com.redhat.che.keycloak.token.store.service;
+
+import javax.inject.Singleton;
+
+@Singleton
+/**
+ * Shared service to store and retrieve the latest keycloak token being used.
+ */
+public class KeycloakTokenStore {
+
+    private String lastToken;
+
+    public String getLastToken() {
+        return lastToken;
+    }
+
+    public boolean hasLastToken() {
+        return lastToken != null;
+    }
+
+    public void setLastToken(String lastToken) {
+        this.lastToken = lastToken;
+    }
+
+    public String getLastTokenWithoutBearer() {
+        if (lastToken == null) {
+            return null;
+        }
+        return lastToken.replace("Bearer ", "");
+    }
+}

--- a/builds/fabric8-che/plugins/pom.xml
+++ b/builds/fabric8-che/plugins/pom.xml
@@ -18,6 +18,7 @@
     <name>Fabric8 IDE plugins (parent)</name>
     <modules>
         <module>keycloak-plugin-shared</module>
+        <module>keycloak-plugin-token-store</module>
         <module>keycloak-plugin-server</module>
         <module>keycloak-plugin-ide</module>
         <module>keycloak-plugin-token-provider</module>

--- a/builds/fabric8-che/pom.xml
+++ b/builds/fabric8-che/pom.xml
@@ -54,6 +54,12 @@
             </dependency>
             <dependency>
                 <groupId>com.redhat.che</groupId>
+                <artifactId>che-keycloak-plugin-token-store</artifactId>
+                <version>${rh.che.plugins.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.che</groupId>
                 <artifactId>che-plugin-bayesian-lang-server</artifactId>
                 <version>${rh.che.plugins.version}</version>
                 <type>jar</type>


### PR DESCRIPTION
- Keeping the last token used (from Keycloak)AuthenticationFilter) and make it available to the bayesian LS at start time.
- update `KeycloakAuthenticationFilter` so it works well with new upstream websocket URIs