### PR TITLE
Don't update upstream snapshots when building the RH distribution.

### DIFF
--- a/cico_do_build_che.sh
+++ b/cico_do_build_che.sh
@@ -24,7 +24,7 @@ mvnche() {
 }
 
 mkdir $NPM_CONFIG_PREFIX 2>/dev/null
-mvnche -B $* install -U
+mvnche -B $* install
 if [ $? -ne 0 ]; then
   echo "Error building che/rh-che with dashboard"
   exit 1;
@@ -32,7 +32,7 @@ fi
 
 if [ "$DeveloperBuild" != "true" ]
   then
-    mvnche -B -P'!checkout-base-che' -DwithoutDashboard $* install -U
+    mvnche -B -P'!checkout-base-che' -DwithoutDashboard $* install
     if [ $? -ne 0 ]; then
       echo "Error building che/rh-che without dashboard"
       exit 1;


### PR DESCRIPTION
This is important, because now the `openshift-connector-wip` branch,
that we still use, might have the same che version number than more
recent snapshots available from the upstream che maven repository.
