### PR TITLE
rh-che 131 - Changes necessary to enable running workspace on different namespace

### DIFF
--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
@@ -37,11 +37,23 @@ import com.google.common.cache.LoadingCache;
 public class KeycloakUserChecker {
 
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakUserChecker.class);
-    private static final String ENDPOINT = "http://che-host:8080/api/token/user";
+    private static final String CHE_API_ENV_VAR = "CHE_API";
+    private static final String USER_VALIDATOR_API_PATH = "/token/user";
 
+    private static final String CHE_API_ENDPOINT;
+    private static final String USER_VALIDATOR_ENDPOINT;
+    static {
+        String cheApiEndpoint = System.getenv(CHE_API_ENV_VAR);
+        if (cheApiEndpoint != null) {
+            CHE_API_ENDPOINT = cheApiEndpoint.replaceAll("/wsmaster/api", "/api");
+        } else {
+            CHE_API_ENDPOINT = "http://che-host:8080/api";
+        }
+        USER_VALIDATOR_ENDPOINT = CHE_API_ENDPOINT + USER_VALIDATOR_API_PATH;
+    }
     @Inject
     private HttpJsonRequestFactory requestFactory;
-    
+
     /**
      * Cache that stores mappings from user to authorization status.
      */
@@ -52,7 +64,7 @@ public class KeycloakUserChecker {
                 @Override
                 public Boolean load(String auth) throws Exception {
                     try {
-                        String response = requestFactory.fromUrl(ENDPOINT)
+                        String response = requestFactory.fromUrl(USER_VALIDATOR_ENDPOINT)
                                                                               .useGetMethod()
                                                                               .setAuthorizationHeader(auth)
                                                                               .request().asString();


### PR DESCRIPTION
The only change of substance is that instead of hard-coding `http://che-host:8080/` as the Che server API, we instead get the value from the CHE_API environment variable, which is added by Che server when starting the workspace. 

With this change it is possible to run Che and start workspaces in another namespace on minishift, with a few caveats:
1. Manual setup is required: Necessary steps are
    - Create a second namespace
    - Ensure PVC `claim-che-workspace` is bound to the second namespace instead of `eclipse-che`
    - Update che deployment config so that `CHE_OPENSHIFT_PROJECT` is `<second-namespace>`
    - Add admin rights to che service account on `<second-namespace>`: `oc adm policy add-role-to-group admin system:serviceaccounts -n <second-namespace>`
2. When running on minishift with the main project name `eclipse-che`, there are no issues, however keycloak authentication for messages between wsmaster and wsagent does not currently work when enabled. I expect this will be easier to implement once Che server is multitenant, as currently there's no good way of validating that incoming messages are what we expect.

Addresses #131 
Depends on https://github.com/eclipse/che/pull/5884