### PR TITLE
rh-che #238: Adding debug commands for vert.x and spring-boot stacks

### DIFF
--- a/builds/fabric8-che/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/builds/fabric8-che/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -69,6 +69,15 @@
                 "previewUrl": "http://${server.port.8080}",
                 "goal": "Run"
             }
+        },
+        {
+            "commandLine": "scl enable rh-maven33 'mvn vertx:debug -f ${current.project.path}'",
+            "name": "debug",
+            "type": "custom",
+            "attributes": {
+              "previewUrl": "http://${server.port.8080}",
+              "goal": "Debug"
+            }
         }]
     },
     "stackIcon": {
@@ -148,6 +157,15 @@
           "attributes": {
             "previewUrl": "http://${server.port.8080}",
             "goal": "Run"
+          }
+        },
+        {
+          "commandLine": "scl enable rh-maven33 'mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\" -f ${current.project.path}'",
+          "name": "debug",
+          "type": "custom",
+          "attributes": {
+            "previewUrl": "http://${server.port.8080}",
+            "goal": "Debug"
           }
         }
       ]


### PR DESCRIPTION
Porting https://github.com/eclipse/che/pull/5938 for adding debug commands to vert.x & spring-boot on osio by default