### PR TITLE
Use localhost instead of che-host service name for checking KC

### DIFF
--- a/builds/fabric8-che/assembly/user-auth-valve/src/main/java/com/redhat/che/valve/UserAuthValve.java
+++ b/builds/fabric8-che/assembly/user-auth-valve/src/main/java/com/redhat/che/valve/UserAuthValve.java
@@ -62,7 +62,7 @@ public class UserAuthValve extends KeycloakAuthenticatorValve {
         if (cheApiEndpoint != null) {
             CHE_API_ENDPOINT = cheApiEndpoint.replaceAll("/wsmaster/api", "/api");
         } else {
-            CHE_API_ENDPOINT = "http://che-host:8080/api";
+            CHE_API_ENDPOINT = "http://localhost:8080/api";
         }
         USER_VALIDATOR_ENDPOINT = CHE_API_ENDPOINT + USER_VALIDATOR_API_PATH;
     }

--- a/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
+++ b/builds/fabric8-che/plugins/keycloak-plugin-server/src/main/java/com/redhat/che/keycloak/server/KeycloakUserChecker.java
@@ -47,7 +47,7 @@ public class KeycloakUserChecker {
         if (cheApiEndpoint != null) {
             CHE_API_ENDPOINT = cheApiEndpoint.replaceAll("/wsmaster/api", "/api");
         } else {
-            CHE_API_ENDPOINT = "http://che-host:8080/api";
+            CHE_API_ENDPOINT = "http://localhost:8080/api";
         }
         USER_VALIDATOR_ENDPOINT = CHE_API_ENDPOINT + USER_VALIDATOR_API_PATH;
     }


### PR DESCRIPTION
Make UserAuthValve and KeycloakUserChecker use localhost instead
of che-host for checkout keycloak tokens when CHE_API env var
is not set

Signed-off-by: Angel Misevski <amisevsk@redhat.com>