### PR TITLE
Fix auth error in script cico_deploy.sh

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -12,6 +12,9 @@ then
   set +x
   cat jenkins-env | grep -e PASS -e DEVSHIFT > inherit-env
   . inherit-env
+  if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "WARNING: failed to get DEVSHIFT_USERNAME from jenkins-env file in centos-ci job."; fi
+  if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "WARNING: failed to get DEVSHIFT_PASSWORD from jenkins-env file in centos-ci job."; fi
+  if [ -z "${RHCHEBOT_DOCKER_HUB_PASSWORD+x}" ]; then echo "WARNING: failed to get RHCHEBOT_DOCKER_HUB_PASSWORD from jenkins-env file in centos-ci job."; fi
   set -x
   yum -y update
   yum -y install centos-release-scl java-1.8.0-openjdk-devel git patch bzip2 golang docker subversion

--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -2,10 +2,15 @@
 set -u
 set +e
 
-# Prepare config files
-# CHE_SERVER_DOCKER_IMAGE_TAG has to be set in che_image_tag.env file
+# Retrieve credentials to push the image to the docker hub
+cat jenkins-env | grep PASS > inherit-env
+. inherit-env
 . config
+
+# CHE_SERVER_DOCKER_IMAGE_TAG has to be set in che_image_tag.env file
 . ~/che_image_tag.env
+
+# Prepare config file
 config_file=~/tests_config
 echo "export OSO_MASTER_URL=https://api.starter-us-east-2.openshift.com:443" >> $config_file
 echo "export OSO_NAMESPACE=mlabuda-jenkins" >> $config_file

--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -3,7 +3,7 @@ set -u
 set +e
 
 # Retrieve credentials to push the image to the docker hub
-cat jenkins-env | grep PASS > inherit-env
+cat jenkins-env | grep -e PASS -e DEVSHIFT > inherit-env
 . inherit-env
 . config
 

--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -5,6 +5,10 @@ set +e
 # Retrieve credentials to push the image to the docker hub
 cat jenkins-env | grep -e PASS -e DEVSHIFT > inherit-env
 . inherit-env
+if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "WARNING: failed to get DEVSHIFT_USERNAME from jenkins-env file in centos-ci job."; fi
+if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "WARNING: failed to get DEVSHIFT_PASSWORD from jenkins-env file in centos-ci job."; fi
+if [ -z "${RHCHEBOT_DOCKER_HUB_PASSWORD+x}" ]; then echo "WARNING: failed to get RHCHEBOT_DOCKER_HUB_PASSWORD from jenkins-env file in centos-ci job."; fi
+
 . config
 
 # CHE_SERVER_DOCKER_IMAGE_TAG has to be set in che_image_tag.env file


### PR DESCRIPTION
In rh-che job the following error is logged:
 
> Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password

This PR should fix it.