### PR TITLE
Fix CI: Force clean of assembly-ide-war that is always needed for patching. Reactivating without dashboard build (#318)

### DIFF
--- a/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-ide-war/pom.xml
@@ -243,19 +243,17 @@
                             </tasks>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
                     <execution>
-                        <id>clean generated sources in assembly-ide-war</id>
+                        <id>auto-clean</id>
                         <phase>initialize</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>clean</goal>
                         </goals>
-                        <configuration>
-                            <target>
-                                <!-- To bypass a problem in the build when 
-                                    rebuilding without the clean option. -->
-                                <delete dir="${project.build.directory}/generated-sources" verbose="true" />
-                            </target>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/cico_do_build_che.sh
+++ b/cico_do_build_che.sh
@@ -24,7 +24,7 @@ mvnche() {
 }
 
 mkdir $NPM_CONFIG_PREFIX 2>/dev/null
-mvnche -B $* install
+mvnche -B $* clean install
 if [ $? -ne 0 ]; then
   echo "Error building che/rh-che with dashboard"
   exit 1;
@@ -32,10 +32,9 @@ fi
 
 if [ "$DeveloperBuild" != "true" ]
   then
-    echo "Build without dashboard is currently skipped because the CI fails (c.f. https://github.com/redhat-developer/rh-che/issues/318). And by the way it's not used in OSIO yet."
-    # mvnche -B -DwithoutDashboard $* install
-    # if [ $? -ne 0 ]; then
-    #   echo "Error building che/rh-che without dashboard"
-    #   exit 1;
-    # fi
+    mvnche -B -DwithoutDashboard -pl=:fabric8-ide-assembly-ide-war,:fabric8-ide-assembly-main $* install
+    if [ $? -ne 0 ]; then
+      echo "Error building che/rh-che without dashboard"
+      exit 1;
+    fi
 fi


### PR DESCRIPTION
fix #318

Also optimized a bit the project to build the second time: only assembly-ide-war and assembly-main