### PR TITLE
Fix CI: Properly dealing with multiple assembly archive files when building docker images

### DIFF
--- a/cico_do_docker_build_tag_push.sh
+++ b/cico_do_docker_build_tag_push.sh
@@ -33,6 +33,20 @@ do
   docker pull ${CHE_DOCKER_BASE_IMAGE}
   docker tag ${CHE_DOCKER_BASE_IMAGE} eclipse/che-server:local
 
+  DIR=$(cd "$(dirname "$0")"; pwd)
+
+  # Use of folder
+  LOCAL_ASSEMBLY_ZIP="${DIR}"/eclipse-che.tar.gz
+
+  if [ -f "${LOCAL_ASSEMBLY_ZIP}" ]; then
+    rm "${LOCAL_ASSEMBLY_ZIP}"
+  fi
+
+  echo "Linking assembly ${distribution} --> ${LOCAL_ASSEMBLY_ZIP}"
+  ln "${distribution}" "${LOCAL_ASSEMBLY_ZIP}"
+
+
+
   bash ./build.sh --organization:${DOCKER_HUB_NAMESPACE} --tag:${NIGHTLY}
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'

--- a/dockerfiles/che-fabric8/Dockerfile
+++ b/dockerfiles/che-fabric8/Dockerfile
@@ -1,7 +1,4 @@
 FROM eclipse/che-server:local
-RUN rm -rf /home/user/eclipse-che*
-ADD eclipse-che.tar.gz /home/user/
-RUN chmod -R 0777 /home/user/
 
 # Install pcp - collection basics
 # would prefer only pmcd, and not the /bin/pm*tools etc.
@@ -15,3 +12,7 @@ EXPOSE 44321
 
 COPY entrypoint.patch /entrypoint.patch
 RUN patch -p0 < entrypoint.patch
+
+RUN rm -rf /home/user/eclipse-che*
+ADD eclipse-che.tar.gz /home/user/
+RUN chmod -R 0777 /home/user/

--- a/dockerfiles/che-fabric8/build.sh
+++ b/dockerfiles/che-fabric8/build.sh
@@ -8,27 +8,5 @@
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}"/../build.include
 
-
-# grab assembly
-DIR=$(cd "$(dirname "$0")"; pwd)
-
-BUILD_ASSEMBLY_MAIN=${DIR}/../../builds/fabric8-che/assembly/assembly-main
-
-if [ ! -d "${BUILD_ASSEMBLY_MAIN}/target" ]; then
-  echo "${ERROR}Have you built assembly/assemby-main in ${BUILD_ASSEMBLY_MAIN} 'mvn clean install'?"
-  exit 2
-fi
-
-# Use of folder
-BUILD_ASSEMBLY_ZIP=$(echo "${BUILD_ASSEMBLY_MAIN}"/target/eclipse-che-*.tar.gz)
-LOCAL_ASSEMBLY_ZIP="${DIR}"/eclipse-che.tar.gz
-
-if [ -f "${LOCAL_ASSEMBLY_ZIP}" ]; then
-  rm "${LOCAL_ASSEMBLY_ZIP}"
-fi
-
-echo "Linking assembly ${BUILD_ASSEMBLY_ZIP} --> ${LOCAL_ASSEMBLY_ZIP}"
-ln "${BUILD_ASSEMBLY_ZIP}" "${LOCAL_ASSEMBLY_ZIP}"
-
 init --name:server "$@" 
 build


### PR DESCRIPTION
[![Review](http://localhost:8080/factory/resources/factory-review.svg)](http://localhost:8080/f?id=factoryqtd8gjzo0dkq304j)

