### PR TITLE
Fix and re-enable pushing images to devshift

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -12,9 +12,9 @@ then
   set +x
   cat jenkins-env | grep -e PASS -e DEVSHIFT > inherit-env
   . inherit-env
-  if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "WARNING: failed to get DEVSHIFT_USERNAME from jenkins-env file in centos-ci job."; fi
-  if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "WARNING: failed to get DEVSHIFT_PASSWORD from jenkins-env file in centos-ci job."; fi
-  if [ -z "${RHCHEBOT_DOCKER_HUB_PASSWORD+x}" ]; then echo "WARNING: failed to get RHCHEBOT_DOCKER_HUB_PASSWORD from jenkins-env file in centos-ci job."; fi
+  if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "WARNING: failed to get DEVSHIFT_USERNAME from jenkins-env file in centos-ci job."; else export DEVSHIFT_USERNAME; fi
+  if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "WARNING: failed to get DEVSHIFT_PASSWORD from jenkins-env file in centos-ci job."; else export DEVSHIFT_PASSWORD; fi
+  if [ -z "${RHCHEBOT_DOCKER_HUB_PASSWORD+x}" ]; then echo "WARNING: failed to get RHCHEBOT_DOCKER_HUB_PASSWORD from jenkins-env file in centos-ci job."; else export RHCHEBOT_DOCKER_HUB_PASSWORD; fi
   set -x
   yum -y update
   yum -y install centos-release-scl java-1.8.0-openjdk-devel git patch bzip2 golang docker subversion

--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -5,10 +5,6 @@ set +e
 # Retrieve credentials to push the image to the docker hub
 cat jenkins-env | grep -e PASS -e DEVSHIFT > inherit-env
 . inherit-env
-if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "WARNING: failed to get DEVSHIFT_USERNAME from jenkins-env file in centos-ci job."; fi
-if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "WARNING: failed to get DEVSHIFT_PASSWORD from jenkins-env file in centos-ci job."; fi
-if [ -z "${RHCHEBOT_DOCKER_HUB_PASSWORD+x}" ]; then echo "WARNING: failed to get RHCHEBOT_DOCKER_HUB_PASSWORD from jenkins-env file in centos-ci job."; fi
-
 . config
 
 # CHE_SERVER_DOCKER_IMAGE_TAG has to be set in che_image_tag.env file
@@ -31,9 +27,39 @@ echo "CHE VALIDATION: Verification skipped until job devtools-che-functional-tes
 # cp jenkins-env che-functional-tests/jenkins-env
 # cd che-functional-tests
 # . cico_run_EE_tests.sh
-
 # echo "CHE VALIDATION: Verification passed. Pushing Che server image to prod registry."
-docker login -u ${DOCKER_HUB_USER} -p ${DOCKER_HUB_PASSWORD} -e noreply@redhat.com
-docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG} rhche/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}
-docker push rhche/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}
-echo "CHE VALIDATION: Image pushed"
+
+STAGE_IMAGE_TO_PROMOTE="${DOCKER_HUB_NAMESPACE}/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}"
+PROD_IMAGE_DEVSHIFT="push.registry.devshift.net/che/che:${CHE_SERVER_DOCKER_IMAGE_TAG}"
+
+echo "CHE VALIDATION: Pushing image ${PROD_IMAGE_DEVSHIFT} to devshift"
+
+if ([ -z "${DEVSHIFT_USERNAME+x}" ] || [ -z "${DEVSHIFT_PASSWORD+x}" ]); then
+    echo "ERROR: Cannot push to registry.devshift.net: credentials are not set. Aborting"
+    exit 1
+fi
+
+docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" push.registry.devshift.net
+docker tag "${STAGE_IMAGE_TO_PROMOTE}" "${PROD_IMAGE_DEVSHIFT}"
+docker push "${PROD_IMAGE_DEVSHIFT}"
+
+echo "CHE VALIDATION: Image pushed to devshift registry"
+
+# We need to continue pushing to the Docker Hub until we have setup a webhook for 
+# repository che/che on devshift. The webhook should trigger
+# https://jenkins.cd.test.fabric8.io/che-version-updater/notify 
+# every time a new version of Che is available 
+PROD_IMAGE_DOCKER_HUB="rhche/che-server:${CHE_SERVER_DOCKER_IMAGE_TAG}"
+
+echo "CHE VALIDATION: Pushing ${PROD_IMAGE_DOCKER_HUB} image Docker Hub"
+
+if ([ -z "${DOCKER_HUB_USER+x}" ] || [ -z "${DOCKER_HUB_PASSWORD+x}" ]); then
+    echo "ERROR: Cannot push images to Docker Hub: credentials are not set. Aborting"
+    exit 1
+fi
+
+docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_PASSWORD}"
+docker tag "${STAGE_IMAGE_TO_PROMOTE}" "${PROD_IMAGE_DOCKER_HUB}"
+docker push "${PROD_IMAGE_DOCKER_HUB}"
+
+echo "CHE VALIDATION: Image pushed to Docker Hub"

--- a/cico_do_docker_build_tag_push.sh
+++ b/cico_do_docker_build_tag_push.sh
@@ -69,14 +69,16 @@ do
     docker push ${DOCKER_HUB_NAMESPACE}/che-server:${TAG}
     
     if [ "${DOCKER_HUB_USER}" == "${RHCHEBOT_DOCKER_HUB_USER}" ]; then
-    # lets also push it to push.registry.devshift.net
-      if [ -z "${DEVSHIFT_USERNAME+x}" ]; then echo "DEVSHIFT_USERNAME is unset."; fi
-      if [ -z "${DEVSHIFT_PASSWORD+x}" ]; then echo "DEVSHIFT_PASSWORD is unset."; fi
-      # docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} -e noreply@redhat.com push.registry.devshift.net
-      # docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${NIGHTLY}
-      # docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${TAG}
-      # docker push push.registry.devshift.net/che/che:${NIGHTLY}
-      # docker push push.registry.devshift.net/che/che:${TAG}
+      # lets also push it to push.registry.devshift.net
+      if ([ -z "${DEVSHIFT_USERNAME+x}" ] || [ -z "${DEVSHIFT_PASSWORD+x}" ]); then
+        echo "WARNING: Cannot push to registry.devshift.net: credentials are not set"
+      else
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} -e noreply@redhat.com push.registry.devshift.net
+        docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${NIGHTLY}
+        docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${TAG}
+        docker push push.registry.devshift.net/che/che:${NIGHTLY}
+        docker push push.registry.devshift.net/che/che:${TAG}
+      fi
     fi
   fi
 done

--- a/cico_do_docker_build_tag_push.sh
+++ b/cico_do_docker_build_tag_push.sh
@@ -44,9 +44,7 @@ do
 
   echo "Linking assembly ${distribution} --> ${LOCAL_ASSEMBLY_ZIP}"
   ln "${distribution}" "${LOCAL_ASSEMBLY_ZIP}"
-
-
-
+  
   bash ./build.sh --organization:${DOCKER_HUB_NAMESPACE} --tag:${NIGHTLY}
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'
@@ -64,22 +62,8 @@ do
   if [ "$DeveloperBuild" != "true" ]
   then
     docker login -u ${DOCKER_HUB_USER} -p $DOCKER_HUB_PASSWORD -e noreply@redhat.com 
-    
     docker push ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY}
     docker push ${DOCKER_HUB_NAMESPACE}/che-server:${TAG}
-    
-    if [ "${DOCKER_HUB_USER}" == "${RHCHEBOT_DOCKER_HUB_USER}" ]; then
-      # lets also push it to push.registry.devshift.net
-      if ([ -z "${DEVSHIFT_USERNAME+x}" ] || [ -z "${DEVSHIFT_PASSWORD+x}" ]); then
-        echo "WARNING: Cannot push to registry.devshift.net: credentials are not set"
-      else
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} -e noreply@redhat.com push.registry.devshift.net
-        docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${NIGHTLY}
-        docker tag ${DOCKER_HUB_NAMESPACE}/che-server:${NIGHTLY} push.registry.devshift.net/che/che:${TAG}
-        docker push push.registry.devshift.net/che/che:${NIGHTLY}
-        docker push push.registry.devshift.net/che/che:${TAG}
-      fi
-    fi
   fi
 done
 


### PR DESCRIPTION
Related to #295. Variables `DEVSHIFT_USERNAME` and `DEVSHIFT_PASSWORD` were not set when running script `cico_do_docker_build_tag_push.sh` because they were not exported in `cico_build.sh`. Now explicitly export them.