### PR TITLE
Logging in json format using logstash-logback-encoder (#311)

### DIFF
--- a/builds/fabric8-che/assembly/assembly-main/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-main/pom.xml
@@ -24,6 +24,22 @@
     <name>Fabric8 IDE :: Assemblies Tomcat</name>
     <dependencies>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.redhat.che</groupId>
             <artifactId>fabric8-ide-assembly-wsagent-server</artifactId>
             <type>tar.gz</type>
@@ -41,6 +57,14 @@
         <dependency>
             <groupId>com.redhat.che</groupId>
             <artifactId>user-auth-valve</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/builds/fabric8-che/assembly/assembly-main/src/assembly/base-component.xml
+++ b/builds/fabric8-che/assembly/assembly-main/src/assembly/base-component.xml
@@ -31,6 +31,19 @@
                 <include>com.redhat.che:fabric8-ide-assembly-wsagent-server</include>
             </includes>
         </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>false</unpack>
+            <outputDirectory>tomcat/lib</outputDirectory>
+            <includes>
+                <include>net.logstash.logback:logstash-logback-encoder</include>
+                <include>ch.qos.logback:logback-classic</include>
+                <include>org.slf4j:slf4j-api</include>
+                <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                <include>com.fasterxml.jackson.core:jackson-core</include>
+                <include>com.fasterxml.jackson.core:jackson-databind</include>
+            </includes>
+        </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>
@@ -44,15 +57,24 @@
                 <exclude>**/tomcat/webapps/swagger.war</exclude>
                 <exclude>**/tomcat/webapps/docs.war</exclude>
                 <exclude>**/stacks/stacks.json</exclude>
+                <exclude>**/tomcat/conf/logback.xml</exclude>
             </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/keycloak/</directory>
             <outputDirectory>tomcat/lib</outputDirectory>
+            <excludes>
+                <!-- avoid conflicts with jackson version used in Che -->
+                <exclude>jackson*.jar</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/stacks/</directory>
             <outputDirectory>stacks/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/assembly/logback/</directory>
+            <outputDirectory>tomcat/conf</outputDirectory>
         </fileSet>
     </fileSets>
 </component>

--- a/builds/fabric8-che/assembly/assembly-main/src/assembly/logback/logback.xml
+++ b/builds/fabric8-che/assembly/assembly-main/src/assembly/logback/logback.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2016-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<configuration>
+
+    <property name="max.retention.days" value="60" />
+
+    <jmxConfigurator/>
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <append>true</append>
+        <prudent>true</prudent>
+        <encoder>
+            <charset>utf-8</charset>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="file-json" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${che.logs.dir}/catalina.log.json</file>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+          <level>info</level>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log.json</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>
+
+    <logger name="org.apache.catalina.loader" level="OFF"/>
+    <logger name="org.apache.catalina.session.PersistentManagerBase" level="OFF"/>
+    <logger name="org.apache.jasper.servlet.TldScanner" level="OFF"/>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="stdout"/>
+        <appender-ref ref="file"/>
+        <appender-ref ref="file-json"/>
+    </root>
+</configuration>

--- a/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
+++ b/builds/fabric8-che/assembly/assembly-wsmaster-war/pom.xml
@@ -60,8 +60,33 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -86,6 +111,14 @@
                             <artifactId>assembly-wsmaster-war</artifactId>
                             <type>war</type>
                             <excludes>
+                                <!-- these jars that are already in the tomcat root lib folder for json logback encoder usage -->
+                                <exclude>WEB-INF/lib/logback-classic-${ch.qos.logback.version}.jar</exclude>
+                                <exclude>WEB-INF/lib/logback-core-${ch.qos.logback.version}.jar</exclude>
+                                <exclude>WEB-INF/lib/slf4j-api-${org.slf4j.version}.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-core-${com.fasterxml.jackson.core.version}.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-databind-${com.fasterxml.jackson.core.version}.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-annotations-${com.fasterxml.jackson.core.version}.jar</exclude>
+                                <!-- end exclude for json logback encoder -->
                                 <exclude>WEB-INF/lib/che-core-ide-stacks-${che.version}.jar</exclude>
                                 <exclude>WEB-INF/classes/che-in-che.json</exclude>
                             </excludes>

--- a/builds/fabric8-che/pom.xml
+++ b/builds/fabric8-che/pom.xml
@@ -30,6 +30,7 @@
     </modules>
     <properties>
         <keycloak.version>2.5.0.Final</keycloak.version>
+        <logstash.logback.encoder.version>4.11</logstash.logback.encoder.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>
         <withoutDashboard>false</withoutDashboard>
@@ -138,6 +139,11 @@
                 <artifactId>user-auth-valve</artifactId>
                 <version>${redhat.che.version}</version>
                 <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>${logstash.logback.encoder.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
This is logging into `/data/logs/catalina.log.json` and then archiving in `/data/logs/archive/2017/09/19/catalina.log.json`

For now, by default, it looks like:
```
{"@timestamp":"2017-09-19T06:48:11.877+00:00","@version":1,"message":"Database: jdbc:h2:che (H2 1.4)","logger_name":"org.flywaydb.core.internal.dbsupport.DbSupportFactory","thread_name":"localhost-startStop-1","level":"INFO","level_va
lue":20000}                                                                                                                                                                                                                               
{"@timestamp":"2017-09-19T06:48:12.957+00:00","@version":1,"message":"Flyway 4.0.3 by Boxfuse","logger_name":"org.flywaydb.core.internal.util.VersionPrinter","thread_name":"localhost-startStop-1","level":"INFO","level_value":20000}   
{"@timestamp":"2017-09-19T06:48:12.965+00:00","@version":1,"message":"Database: jdbc:h2:che (H2 1.4)","logger_name":"org.flywaydb.core.internal.dbsupport.DbSupportFactory","thread_name":"localhost-startStop-1","level":"INFO","level_va
lue":20000}                                                                                                                                                                                                                               
{"@timestamp":"2017-09-19T06:48:13.058+00:00","@version":1,"message":"Searching for sql scripts in locations [classpath:che-schema]","logger_name":"org.eclipse.che.core.db.schema.impl.flyway.CustomSqlMigrationResolver","thread_name":"
localhost-startStop-1","level":"INFO","level_value":20000}                                                                                                                                                                                
{"@timestamp":"2017-09-19T06:48:13.166+00:00","@version":1,"message":"Successfully validated 11 migrations (execution time 00:00.110s)","logger_name":"org.flywaydb.core.internal.command.DbValidate","thread_name":"localhost-startStop-1
","level":"INFO","level_value":20000}                                                                                                                                                                                                     
{"@timestamp":"2017-09-19T06:48:13.262+00:00","@version":1,"message":"Current version of schema \"PUBLIC\": 5.11.0.1","logger_name":"org.flywaydb.core.internal.command.DbMigrate","thread_name":"localhost-startStop-1","level":"INFO","l
evel_value":20000}                                                                                                                                                                                                                        
{"@timestamp":"2017-09-19T06:48:13.273+00:00","@version":1,"message":"Schema \"PUBLIC\" is up to date. No migration necessary.","logger_name":"org.flywaydb.core.internal.command.DbMigrate","thread_name":"localhost-startStop-1","level"
:"INFO","level_value":20000}                                                                                                                                                                                                              
{"@timestamp":"2017-09-19T06:48:18.300+00:00","@version":1,"message":"Idling che server scheduled [timeout=3600] seconds]","logger_name":"org.eclipse.che.api.workspace.server.idle.ServerIdleDetector","thread_name":"localhost-startStop
-1","level":"INFO","level_value":20000}                                                                                                                                                                                                   
{"@timestamp":"2017-09-19T06:48:18.232+00:00","@version":1,"message":"List containers registered in the api: []","logger_name":"org.eclipse.che.plugin.docker.machine.cleaner.DockerAbandonedResourcesCleaner","thread_name":"Annotated-sc
heduler-1","level":"INFO","level_value":20000}                                                                                                                                                                                            
{"@timestamp":"2017-09-19T06:48:18.387+00:00","@version":1,"message":"Keycloak is disabled","logger_name":"com.redhat.che.keycloak.server.KeycloakAuthenticationFilter","thread_name":"localhost-startStop-1","level":"INFO","level_value"
:20000}
```

In this PR, the major problem was that we have to use jackson and logback dependencies in the tomcat root classloader (not the webapp one) and it causes classloading issues. So some jars had to be moved to the tomcat/lib folder.

This PR uses logstash-logback-encoder. We could have use https://github.com/qos-ch/logback-contrib as well. Pros for logstash one is that it suits well with ELK (then it's a matter of naming). Pros for  Logback JSON extension is that it's hosted by qos-ch github repo. But classloading hell would be the same.
