### PR TITLE
Modify URL to fetch user's github account token

### DIFF
--- a/dev-scripts/openshift_deploy.sh
+++ b/dev-scripts/openshift_deploy.sh
@@ -85,7 +85,7 @@ K8S_VERSION_PRIOR_TO_1_6=${K8S_VERSION_PRIOR_TO_1_6:-${DEFAULT_K8S_VERSION_PRIOR
 # Keycloak production endpoints are used by default
 DEFAULT_KEYCLOAK_OSO_ENDPOINT="https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token"
 KEYCLOAK_OSO_ENDPOINT=${KEYCLOAK_OSO_ENDPOINT:-${DEFAULT_KEYCLOAK_OSO_ENDPOINT}}
-DEFAULT_KEYCLOAK_GITHUB_ENDPOINT="https://sso.openshift.io/auth/realms/fabric8/broker/github/token"
+DEFAULT_KEYCLOAK_GITHUB_ENDPOINT="https://auth.openshift.io/api/token?for=https://github.com"
 KEYCLOAK_GITHUB_ENDPOINT=${KEYCLOAK_GITHUB_ENDPOINT:-${DEFAULT_KEYCLOAK_GITHUB_ENDPOINT}}
 
 # OPENSHIFT_FLAVOR can be minishift or openshift


### PR DESCRIPTION
This fix is a part of https://github.com/fabric8-services/fabric8-auth/issues/149
fixes #379 


The token to fetch github url has changed and this PR addresses that.

Please note: that the default response of this url is `application/json`.

I haven't manually tested this PR - hoping that I could depend on CI tests? If not, let me know and I will test it manually :)

CC: @alexeykazakov 