### PR TITLE
rh-che #379: Adding missing 'com.fasterxml.jackson.core' dependency

### DIFF
--- a/plugins/keycloak-plugin-token-provider/pom.xml
+++ b/plugins/keycloak-plugin-token-provider/pom.xml
@@ -25,6 +25,10 @@
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Fixes broken build https://ci.centos.org/job/devtools-build-run-che-build-master/451/

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/379

### How have you tested this PR?
tested build locally
