### PR TITLE
Fixing local_docker_create_images_and_tag.sh script with right location of cico scripts

### DIFF
--- a/dev-scripts/local_docker_create_images_and_tag.sh
+++ b/dev-scripts/local_docker_create_images_and_tag.sh
@@ -9,7 +9,7 @@ export DeveloperBuild="true"
 
 currentDir=$(pwd)
 
-cd $(dirname "$0")/..
+cd $(dirname "$0")/../.ci/
 
 bash ./cico_do_docker_build_tag_push.sh
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
[![Review](http://localhost:8080/factory/resources/factory-review.svg)](http://localhost:8080/f?id=factory8m79op8lcnk5qwln)

