### PR TITLE
Fix 6891

### DIFF
--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -79,7 +79,7 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
       return clusterUrl;
     }
 
-    public String getRoutePrefix() {
+    public String getRouteBaseSuffix() {
       return routePrefix;
     }
 

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserBasedWorkspacesRoutingSuffixProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserBasedWorkspacesRoutingSuffixProvider.java
@@ -10,6 +10,7 @@
  */
 package com.redhat.che.multitenant;
 
+import com.redhat.che.multitenant.Fabric8WorkspaceEnvironmentProvider.UserCheTenantData;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -18,8 +19,6 @@ import org.eclipse.che.plugin.docker.client.WorkspacesRoutingSuffixProvider;
 import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.redhat.che.multitenant.Fabric8WorkspaceEnvironmentProvider.UserCheTenantData;
 
 /**
  * Retrieves a routing suffix that can be used when building workspace agents external address with
@@ -54,9 +53,9 @@ public class UserBasedWorkspacesRoutingSuffixProvider extends WorkspacesRoutingS
   @Override
   @Nullable
   public String get() {
-      UserCheTenantData userCheTenantData;
-      try {
-       userCheTenantData = workspaceEnvironmentProvider.getUserCheTenantData();
+    UserCheTenantData userCheTenantData;
+    try {
+      userCheTenantData = workspaceEnvironmentProvider.getUserCheTenantData();
     } catch (OpenShiftException e) {
       LOG.warn("Exception when trying to retrieve routing suffix from user tenant data", e);
       return null;
@@ -66,9 +65,9 @@ public class UserBasedWorkspacesRoutingSuffixProvider extends WorkspacesRoutingS
       suffix = cheWorkspacesRoutingSuffix;
     }
     if (suffix == null) {
-        return null;
+      return null;
     }
-    
+
     return new StringBuilder(userCheTenantData.getNamespace())
         .append('.')
         .append(suffix)


### PR DESCRIPTION
### What does this PR do?

This PR makes the `OpenshiftConnector` workspace route naming rule consistent
with custom server evaluation strategy in all cases (especially in case
of unexpected openshift.io user name).

It corresponds to the following upstream Che PR: https://github.com/eclipse/che/pull/7017

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/6891
