### PR TITLE
Updated nodejs stack to use nodejs6 in default run command

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -673,7 +673,7 @@
 },
 {
   "name": "CentOS nodejs",
-  "id": "nodejs4",
+  "id": "nodejs6",
   "creator": "Dharmit Shah",
   "scope": "general",
     "source": {
@@ -725,7 +725,7 @@
             "goal": "Run",
             "previewUrl": "http://${server.port.8080}"
           },
-          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs4 'node app/app.js'"
+          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs6 'node app/app.js'"
         }
       ],
       "defaultEnv": "default",


### PR DESCRIPTION
### What does this PR do?
Changed the node stack to use rh-nodejs6 instead of rh-nodejs4 in the default run command.

### What issues does this PR fix or reference?
In https://github.com/eclipse/che-dockerfiles/commit/f2133bd0fed61ed47d81b9c66c08d83dcfa79aba#diff-6e0645ff7ade28082a8ffd0a66e62e22 node was changed from rh-nodejs4 to rh-nodejs6 but that wasn't reflected in the stacks.

### How have you tested this PR?
Running the stack in rh-che in minishift
