### PR TITLE
openshift.io #1238: Adding keycloak token validation to the '/user' e…

### DIFF
--- a/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/contoller/TokenController.java
+++ b/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/contoller/TokenController.java
@@ -104,7 +104,7 @@ public class TokenController {
     try {
       validator.validate(keycloakToken);
       token = tokenProvider.obtainOsoToken(keycloakToken);
-    } catch (Exception e) {
+    } catch (KeycloakException e) {
       return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
     return Response.ok(token).build();
@@ -117,10 +117,17 @@ public class TokenController {
         "Return true if the token provided in the authorization header corresponds to the user who owns the namespace."
   )
   public Response getUserMatches(@HeaderParam(HttpHeaders.AUTHORIZATION) String keycloakToken) {
-    if (userValidator.matchesUsername(keycloakToken)) {
-      return Response.ok("true").build();
-    } else {
-      return Response.ok("false").build();
+    try {
+      validator.validate(keycloakToken);
+      Response response;
+      if (userValidator.matchesUsername(keycloakToken)) {
+        response = Response.ok("true").build();
+      } else {
+        response = Response.ok("false").build();
+      }
+      return response;
+    } catch (KeycloakException e) {
+      return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
   }
 }

--- a/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/validator/KeycloakTokenValidator.java
+++ b/plugins/keycloak-plugin-token-provider/src/main/java/com/redhat/che/keycloak/token/provider/validator/KeycloakTokenValidator.java
@@ -16,15 +16,22 @@ import org.apache.commons.lang3.StringUtils;
 
 @Singleton
 public class KeycloakTokenValidator {
-  private static final String BEARER_PREFIX = "Bearer ";
+  private static final String BEARER_PREFIX = "Bearer";
 
   public void validate(final String keycloakToken) throws KeycloakException {
-    if (!isValid(keycloakToken)) {
+    if (!hasBearerPrefix(keycloakToken)) {
       throw new KeycloakException("Keycloak token must have '" + BEARER_PREFIX + "' prefix");
+    } else if (isTokenBlank(keycloakToken)) {
+      throw new KeycloakException("Keycloak token is blank: '" + keycloakToken + "'");
     }
   }
 
-  private boolean isValid(final String keycloakToken) {
-    return (StringUtils.isNotBlank(keycloakToken) && keycloakToken.startsWith(BEARER_PREFIX));
+  private boolean hasBearerPrefix(final String keycloakToken) {
+    return (StringUtils.isNotBlank(keycloakToken) && keycloakToken.startsWith(BEARER_PREFIX + " "));
+  }
+
+  private boolean isTokenBlank(final String keycloakToken) {
+    String token = StringUtils.replaceOnce(keycloakToken, BEARER_PREFIX, "");
+    return StringUtils.isBlank(token);
   }
 }

--- a/plugins/keycloak-plugin-token-provider/src/test/java/com/redhat/che/keycloak/token/provider/validator/KeycloakTokenValidatorTest.java
+++ b/plugins/keycloak-plugin-token-provider/src/test/java/com/redhat/che/keycloak/token/provider/validator/KeycloakTokenValidatorTest.java
@@ -15,6 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class KeycloakTokenValidatorTest {
+  private static final String BLANK_TOKEN = "Bearer ";
   private static final String VALID_TOKEN = "Bearer token";
   private static final String INVALID_TOKEN = "token";
   private static KeycloakTokenValidator keycloakTokenValidator;
@@ -32,5 +33,10 @@ public class KeycloakTokenValidatorTest {
   @Test(expected = KeycloakException.class)
   public void processInvalidToken() throws KeycloakException {
     keycloakTokenValidator.validate(INVALID_TOKEN);
+  }
+
+  @Test(expected = KeycloakException.class)
+  public void processBlankToken() throws KeycloakException {
+    keycloakTokenValidator.validate(BLANK_TOKEN);
   }
 }


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Adding keycloak token validation to the '/user' endpoint

### What issues does this PR fix or reference?
Improving diagnostics of https://github.com/openshiftio/openshift.io/issues/1238

### How have you tested this PR?
run the tests locally 
