### PR TITLE
Adding build status icon to 'multi-tenant-rh-che' README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-build-run-che-build-multi-tenant-rh-che](https://ci.centos.org/view/Devtools/job/devtools-build-run-che-build-multi-tenant-rh-che)
+
 # Eclipse Che on OpenShift 
 
 ## Table Of Content


### PR DESCRIPTION
### What does this PR do?
Adding build status icon to 'multi-tenant-rh-che' README.md

### What issues does this PR fix or reference?
Acctually, I just need a dummy commit in order to pick up David's fix for external url protocol and have the latest `che-server-multiuser` image
