### PR TITLE
Removed scl enable rh-nodejs6 dependency in node stack

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -673,7 +673,7 @@
 },
 {
   "name": "CentOS nodejs",
-  "id": "nodejs4",
+  "id": "nodejs6",
   "creator": "Dharmit Shah",
   "scope": "general",
     "source": {
@@ -725,7 +725,7 @@
             "goal": "Run",
             "previewUrl": "http://${server.port.8080}"
           },
-          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs4 'node app/app.js'"
+          "commandLine": "cd ${current.project.path} && node app/app.js"
         }
       ],
       "defaultEnv": "default",


### PR DESCRIPTION
### What does this PR do?
Removes scl enable rh-nodejs6 dependency in node js stack

### What issues does this PR fix or reference?
scl enable rh-nodejs is no longer needed as of eclipse/che-dockerfiles@8e70296cb5a9bd79add294b3ce1bd55daf414798

### How have you tested this PR?
Tested manually by using the run command in the stack on a nodejs project