### PR TITLE
Bayesian compatibility and workspace cleaning with multi-tenancy

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
@@ -12,8 +12,6 @@ package com.redhat.che.wsmaster.deploy;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import com.redhat.bayesian.agent.BayesianAgent;
-import org.eclipse.che.api.agent.shared.model.Agent;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.multiuser.keycloak.token.provider.oauth.OpenShiftGitHubOAuthAuthenticator;
 import org.eclipse.che.security.oauth.OAuthAuthenticator;
@@ -23,8 +21,6 @@ import org.eclipse.che.security.oauth.OAuthAuthenticator;
 public class Fabric8WsMasterModule extends AbstractModule {
   @Override
   protected void configure() {
-    Multibinder<Agent> agents = Multibinder.newSetBinder(binder(), Agent.class);
-    agents.addBinding().to(BayesianAgent.class);
     bind(org.eclipse.che.api.workspace.server.WorkspaceFilesCleaner.class)
         .to(org.eclipse.che.plugin.openshift.client.OpenShiftWorkspaceFilesCleaner.class);
     Multibinder<OAuthAuthenticator> oAuthAuthenticators =

--- a/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
+++ b/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
@@ -76,7 +76,7 @@ public class BayesianLanguageServerLauncher extends LanguageServerLauncherTempla
 
     try {
       String endpoint = apiEndpoint + "/bayesian/token";
-      LOG.info("Retrieving the Bayesian recommender token from API : {}", endpoint);
+      LOG.debug("Retrieving the Bayesian recommender token from API : {}", endpoint);
       recommenderToken = httpJsonFactory.fromUrl(endpoint).request().asString();
     } catch (Exception e) {
       throw new LanguageServerException("Can't start Bayesian language server", e);

--- a/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
+++ b/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
@@ -82,8 +82,6 @@ public class BayesianLanguageServerLauncher extends LanguageServerLauncherTempla
       throw new LanguageServerException("Can't start Bayesian language server", e);
     }
 
-    LOG.info("Recommender token : {}", recommenderToken);
-
     String launchCommand =
         "export RECOMMENDER_API_TOKEN=\"" + recommenderToken + "\" && " + launchScript.toString();
 

--- a/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
+++ b/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerLauncher.java
@@ -10,14 +10,17 @@
  */
 package org.eclipse.che.plugin.languageserver.bayesian.server.launcher;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.redhat.che.keycloak.token.store.service.KeycloakTokenStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import javax.inject.Named;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.languageserver.exception.LanguageServerException;
 import org.eclipse.che.api.languageserver.launcher.LanguageServerLauncherTemplate;
 import org.eclipse.che.api.languageserver.registry.DocumentFilter;
@@ -27,6 +30,7 @@ import org.eclipse.che.plugin.languageserver.bayesian.BayesianLanguageServerModu
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.slf4j.Logger;
 
 /**
  * @author Evgen Vidolob
@@ -34,15 +38,19 @@ import org.eclipse.lsp4j.services.LanguageServer;
  */
 @Singleton
 public class BayesianLanguageServerLauncher extends LanguageServerLauncherTemplate {
+  private static final Logger LOG = getLogger(BayesianLanguageServerLauncher.class);
 
   private static final LanguageServerDescription DESCRIPTION = createServerDescription();
 
   private final Path launchScript;
-
-  @Inject private KeycloakTokenStore keycloakStore;
+  private final HttpJsonRequestFactory httpJsonFactory;
+  private final String apiEndpoint;
 
   @Inject
-  public BayesianLanguageServerLauncher() {
+  public BayesianLanguageServerLauncher(
+      HttpJsonRequestFactory httpJsonFactory, @Named("che.api") String apiEndpoint) {
+    this.httpJsonFactory = httpJsonFactory;
+    this.apiEndpoint = apiEndpoint;
     launchScript = Paths.get(System.getenv("HOME"), "che/ls-bayesian/launch.sh");
   }
 
@@ -64,18 +72,20 @@ public class BayesianLanguageServerLauncher extends LanguageServerLauncherTempla
   }
 
   protected Process startLanguageServerProcess(String projectPath) throws LanguageServerException {
-    String launchCommand = launchScript.toString();
+    String recommenderToken = null;
 
-    if (keycloakStore.hasLastToken()) {
-      launchCommand =
-          "export RECOMMENDER_API_TOKEN="
-              + //
-              keycloakStore.getLastTokenWithoutBearer()
-              + //
-              " && "
-              + //
-              launchCommand;
+    try {
+      String endpoint = apiEndpoint + "/bayesian/token";
+      LOG.info("Retrieving the Bayesian recommender token from API : {}", endpoint);
+      recommenderToken = httpJsonFactory.fromUrl(endpoint).request().asString();
+    } catch (Exception e) {
+      throw new LanguageServerException("Can't start Bayesian language server", e);
     }
+
+    LOG.info("Recommender token : {}", recommenderToken);
+
+    String launchCommand =
+        "export RECOMMENDER_API_TOKEN=\"" + recommenderToken + "\" && " + launchScript.toString();
 
     ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", "-c", launchCommand);
     processBuilder.redirectInput(ProcessBuilder.Redirect.PIPE);

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -137,23 +137,14 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
 
     String osoToken = getOpenShiftTokenForUser(subject);
     if (osoToken == null) {
-      throw new OpenShiftException(
-          "OSO token not found for user: "
-              + subject.getUserName()
-              + "("
-              + subject.getUserId()
-              + ")");
+      throw new OpenShiftException("OSO token not found for user: " + getUserDescription(subject));
     }
 
     UserCheTenantData cheTenantData;
     cheTenantData = getUserCheTenantData(subject);
     if (cheTenantData == null) {
       throw new OpenShiftException(
-          "User tenant data not found for user: "
-              + subject.getUserName()
-              + "("
-              + subject.getUserId()
-              + ")");
+          "User tenant data not found for user: " + getUserDescription(subject));
     }
 
     return new ConfigBuilder()
@@ -178,6 +169,10 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
     }
   }
 
+  private String getUserDescription(Subject subject) {
+    return subject.getUserName() + "(" + subject.getUserId() + ")";
+  }
+
   public String getOpenShiftTokenForUser(Subject subject) throws OpenShiftException {
 
     checkSubject(subject);
@@ -186,20 +181,14 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
     if (keycloakToken == null) {
       throw new OpenShiftException(
           "User Openshift token is needed but cannot be retrieved since there is no Keycloak token for user: "
-              + subject.getUserName()
-              + "("
-              + subject.getUserId()
-              + ")");
+              + getUserDescription(subject));
     }
     try {
       return tokenCache.get(keycloakToken);
     } catch (ExecutionException e) {
       throw new OpenShiftException(
           "Could not retrieve OSO token from Keycloak token for user: "
-              + subject.getUserName()
-              + "("
-              + subject.getUserId()
-              + ")",
+              + getUserDescription(subject),
           e.getCause());
     }
   }
@@ -290,11 +279,7 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
     UserCheTenantData cheTenantData = getUserCheTenantData(subject);
     if (cheTenantData == null) {
       throw new OpenShiftException(
-          "User tenant data not found for user: "
-              + subject.getUserName()
-              + "("
-              + subject.getUserId()
-              + ")");
+          "User tenant data not found for user: " + getUserDescription(subject));
     }
     return cheTenantData.getNamespace();
   }

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -195,7 +195,7 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
       return tokenCache.get(keycloakToken);
     } catch (ExecutionException e) {
       throw new OpenShiftException(
-          "Cound not retrieve OSO token from Keycloak token for user: "
+          "Could not retrieve OSO token from Keycloak token for user: "
               + subject.getUserName()
               + "("
               + subject.getUserId()

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -35,6 +35,7 @@ import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.multiuser.keycloak.token.provider.service.KeycloakTokenProvider;
 import org.eclipse.che.plugin.openshift.client.OpenshiftWorkspaceEnvironmentProvider;
 import org.eclipse.che.plugin.openshift.client.exception.OpenShiftException;
@@ -116,28 +117,48 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
             .build(CacheLoader.from(this::loadUserCheTenantData));
   }
 
+  private void checkSubject(Subject subject) throws OpenShiftException {
+    if (subject == null) {
+      throw new OpenShiftException("No Subject is found to perform this action");
+    }
+    if (subject == Subject.ANONYMOUS) {
+      throw new OpenShiftException(
+          "The anonymous subject is used, and won't be able to perform this action");
+    }
+  }
+
   @Override
-  public Config getWorkspacesOpenshiftConfig() throws OpenShiftException {
+  public Config getWorkspacesOpenshiftConfig(Subject subject) throws OpenShiftException {
     if (!fabric8CheMultitenant) {
-      return super.getWorkspacesOpenshiftConfig();
+      return super.getWorkspacesOpenshiftConfig(subject);
     }
 
-    String osoToken = getOpenShiftTokenForUser();
+    checkSubject(subject);
+
+    String osoToken = getOpenShiftTokenForUser(subject);
     if (osoToken == null) {
       throw new OpenShiftException(
-          "OSO token is null => Connecting to Openshift with default config");
+          "OSO token not found for user: "
+              + subject.getUserName()
+              + "("
+              + subject.getUserId()
+              + ")");
     }
 
     UserCheTenantData cheTenantData;
-    cheTenantData = getUserCheTenantData();
+    cheTenantData = getUserCheTenantData(subject);
     if (cheTenantData == null) {
       throw new OpenShiftException(
-          "User tenant data not found => Connecting to Openshift with default config");
+          "User tenant data not found for user: "
+              + subject.getUserName()
+              + "("
+              + subject.getUserId()
+              + ")");
     }
 
     return new ConfigBuilder()
         .withMasterUrl(cheTenantData.getClusterUrl())
-        .withOauthToken(getOpenShiftTokenForUser())
+        .withOauthToken(osoToken)
         .withNamespace(cheTenantData.getNamespace())
         .withTrustCerts(true)
         .build();
@@ -153,21 +174,33 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
         | ConflictException
         | BadRequestException
         | IOException e) {
-      throw new RuntimeException(
-          "Cound not retrieve OSO token from Keycloak token: " + keycloakToken, e);
+      throw new RuntimeException("Cound not retrieve OSO token from Keycloak token", e);
     }
   }
 
-  public String getOpenShiftTokenForUser() throws OpenShiftException {
-    String keycloakToken = EnvironmentContext.getCurrent().getSubject().getToken();
+  public String getOpenShiftTokenForUser(Subject subject) throws OpenShiftException {
+
+    checkSubject(subject);
+
+    String keycloakToken = subject.getToken();
     if (keycloakToken == null) {
-      throw new OpenShiftException("User Openshift token is needed but there is no current user");
+      throw new OpenShiftException(
+          "User Openshift token is needed but cannot be retrieved since there is no Keycloak token for user: "
+              + subject.getUserName()
+              + "("
+              + subject.getUserId()
+              + ")");
     }
     try {
       return tokenCache.get(keycloakToken);
     } catch (ExecutionException e) {
       throw new OpenShiftException(
-          "Cound not retrieve OSO token from Keycloak token: " + keycloakToken, e.getCause());
+          "Cound not retrieve OSO token from Keycloak token for user: "
+              + subject.getUserName()
+              + "("
+              + subject.getUserId()
+              + ")",
+          e.getCause());
     }
   }
 
@@ -215,8 +248,10 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
     throw new RuntimeException("No che namespace was found in the user tenant");
   }
 
-  public UserCheTenantData getUserCheTenantData() throws OpenShiftException {
-    String keycloakToken = EnvironmentContext.getCurrent().getSubject().getToken();
+  public UserCheTenantData getUserCheTenantData(Subject subject) throws OpenShiftException {
+    checkSubject(subject);
+
+    String keycloakToken = subject.getToken();
     if (keycloakToken == null) {
       throw new OpenShiftException("User tenant data is needed but there is no current user");
     }
@@ -226,6 +261,10 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
       throw new OpenShiftException(
           "Exception during the user tenant data retrieval or parsing", e.getCause());
     }
+  }
+
+  public UserCheTenantData getUserCheTenantData() throws OpenShiftException {
+    return getUserCheTenantData(EnvironmentContext.getCurrent().getSubject());
   }
 
   private String getResponseBody(final String endpoint, final String keycloakToken)
@@ -241,14 +280,21 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
   }
 
   @Override
-  public String getWorkspacesOpenshiftNamespace() throws OpenShiftException {
+  public String getWorkspacesOpenshiftNamespace(Subject subject) throws OpenShiftException {
     if (!fabric8CheMultitenant) {
-      return super.getWorkspacesOpenshiftNamespace();
+      return super.getWorkspacesOpenshiftNamespace(subject);
     }
 
-    UserCheTenantData cheTenantData = getUserCheTenantData();
+    checkSubject(subject);
+
+    UserCheTenantData cheTenantData = getUserCheTenantData(subject);
     if (cheTenantData == null) {
-      throw new OpenShiftException("User tenant data not found !");
+      throw new OpenShiftException(
+          "User tenant data not found for user: "
+              + subject.getUserName()
+              + "("
+              + subject.getUserId()
+              + ")");
     }
     return cheTenantData.getNamespace();
   }

--- a/plugins/ls-bayesian-agent/pom.xml
+++ b/plugins/ls-bayesian-agent/pom.xml
@@ -27,8 +27,40 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-agent-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.che.core</groupId>
+          <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianAgentModule.java
+++ b/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianAgentModule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.bayesian.agent;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import org.eclipse.che.api.agent.shared.model.Agent;
+import org.eclipse.che.inject.DynaModule;
+
+/** @author David Festal */
+@DynaModule
+public class BayesianAgentModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    Multibinder<Agent> agents = Multibinder.newSetBinder(binder(), Agent.class);
+    agents.addBinding().to(BayesianAgent.class);
+    bind(BayesianTokenProvider.class);
+  }
+}

--- a/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianTokenProvider.java
+++ b/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianTokenProvider.java
@@ -41,7 +41,7 @@ public class BayesianTokenProvider {
   public Response getBayesianToken(@HeaderParam(HttpHeaders.AUTHORIZATION) String machineToken)
       throws NotFoundException {
     String workspaceId = machineTokenRegistry.getWorkspaceId(machineToken);
-    LOG.info("workspaceId for Bayesian recommender token retrieval: {}", workspaceId);
+    LOG.debug("workspaceId for Bayesian recommender token retrieval: {}", workspaceId);
     Subject workspaceStarter = workspaceSubjectRegistry.getWorkspaceStarter(workspaceId);
     if (workspaceStarter == null) {
       LOG.error(

--- a/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianTokenProvider.java
+++ b/plugins/ls-bayesian-agent/src/main/java/com/redhat/bayesian/agent/BayesianTokenProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.bayesian.agent;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.workspace.server.WorkspaceSubjectRegistry;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.machine.authentication.server.MachineTokenRegistry;
+import org.slf4j.Logger;
+
+@Path("/bayesian")
+@Singleton
+public class BayesianTokenProvider {
+  private static final Logger LOG = getLogger(BayesianTokenProvider.class);
+
+  @Inject private MachineTokenRegistry machineTokenRegistry;
+  @Inject private WorkspaceSubjectRegistry workspaceSubjectRegistry;
+
+  @GET
+  @Path("/token")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getBayesianToken(@HeaderParam(HttpHeaders.AUTHORIZATION) String machineToken)
+      throws NotFoundException {
+    String workspaceId = machineTokenRegistry.getWorkspaceId(machineToken);
+    LOG.info("workspaceId for Bayesian recommender token retrieval: {}", workspaceId);
+    Subject workspaceStarter = workspaceSubjectRegistry.getWorkspaceStarter(workspaceId);
+    if (workspaceStarter == null) {
+      LOG.error(
+          "Subject that started workspace '{}' was not found during Bayesian recommender token retrieval.",
+          workspaceId);
+      throw new NotFoundException("Bayesian token not found");
+    }
+    String keycloakToken = workspaceStarter.getToken();
+    if (keycloakToken == null) {
+      LOG.error(
+          "Keycloak token of the subject that started workspace '{}' (user name = '{}' )was not found during Bayesian recommender token retrieval.",
+          workspaceId,
+          workspaceStarter.getUserName());
+      throw new NotFoundException("Bayesian token not found");
+    }
+    return Response.ok("\"" + keycloakToken + '"').build();
+  }
+}


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

This PR now uses the last changes made in upstream to support proper workspace cleaning (PR https://github.com/eclipse/che/pull/7243), and make the Bayesian plugin work with multi-tenancy (issue #376) by:
- creating a service endpoint started on wsmaster along with the
Bayesian Agent, to provide the required up-to-date token (from the user
that started the workspace)  from the machine token of the workspace
agent
- retrieving this token endpoint when starting the language server on
the workspace agent.

### What issues does this PR fix or reference?

#376 

### How have you tested this PR?

Deployed the resulting image on the AWS cluster, started a workspace on my OSIO account, got a Bayesian warning on a `pom.xml` file.