### PR TITLE
Changing link of the 'multi-tenant-rh-che' status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/)](https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/)
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-rh-che-build-che-credentials-multi-tenant-rh-che)](https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/)
 
 # Eclipse Che on OpenShift 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-build-run-che-build-multi-tenant-rh-che)](https://ci.centos.org/view/Devtools/job/devtools-build-run-che-build-multi-tenant-rh-che)
+[![Build Status](https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/)](https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/)
 
 # Eclipse Che on OpenShift 
 


### PR DESCRIPTION
### What does this PR do?
https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-multi-tenant-rh-che/
Using new job status in the Readme.md 
