### PR TITLE
rh-che #395: Changing RoleBiinding from 'admin' to 'edit' openshift template

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -32,7 +32,7 @@ objects:
       app: che
     name: che
   roleRef:
-    name: admin
+    name: edit
   subjects:
   - kind: ServiceAccount
     name: che


### PR DESCRIPTION
### What does this PR do?
Removing RoleBiinding from openshift template
Currently deployment on prod is failing https://ci.centos.org/view/Devtools/job/devtools-saas-openshiftio-promote-to-prod/415/

`Error from server (Forbidden): User "system:serviceaccount:dsaas-production:deploybot" cannot get rolebindings in project "dsaas-production"`


With multi-tenant che-server there is no need 

### What issues does this PR fix or reference?


### How have you tested this PR?
