### PR TITLE
Removing RoleBinding from openshift template

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -26,17 +26,6 @@ objects:
     selector:
       app: che
 - apiVersion: v1
-  kind: RoleBinding
-  metadata:
-    labels:
-      app: che
-    name: che
-  roleRef:
-    name: edit
-  subjects:
-  - kind: ServiceAccount
-    name: che
-- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Currently RoleBinding is forbidden on OSD:

`Error from server (Forbidden): User "system:serviceaccount:dsaas-preview:platformdeployerbot" cannot create rolebindings in project "dsaas-preview"`

Need to investigate why admin / edit RoleBinding is required, currently without it multi-tenant che-server fails with: 


```
1) Error in custom provider, io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/wrong-role/services/che-host. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked..
--
  | while locating org.eclipse.che.plugin.docker.machine.ApiEndpointEnvVariableProvider
  | while locating java.lang.String annotated with @com.google.inject.multibindings.Element(setName=@com.google.inject.name.Named(value=machine.docker.machine_env),uniqueId=50, type=MULTIBINDER, keyType=)
  | at org.eclipse.che.plugin.docker.machine.DockerMachineModule.configure(DockerMachineModule.java:45) (via modules: org.eclipse.che.api.deploy.WsMasterModule -> org.eclipse.che.plugin.docker.machine.local.LocalDockerModule -> org.eclipse.che.plugin.docker.machine.DockerMachineModule -> com.google.inject.multibindings.Multibinder$RealMultibinder)
  | while locating java.util.Set<java.lang.String> annotated with @com.google.inject.name.Named(value=machine.docker.machine_env)
  | for the 18th parameter of org.eclipse.che.plugin.docker.machine.AuthMachineProviderImpl.<init>(AuthMachineProviderImpl.java:72)
  | while locating org.eclipse.che.plugin.docker.machine.AuthMachineProviderImpl
  | while locating org.eclipse.che.api.environment.server.MachineInstanceProvider
  | for the 8th parameter of org.eclipse.che.api.environment.server.CheEnvironmentEngine.<init>(CheEnvironmentEngine.java:143)
  | at org.eclipse.che.api.environment.server.CheEnvironmentEngine.class(CheEnvironmentEngine.java:104)
  | while locating org.eclipse.che.api.environment.server.CheEnvironmentEngine
  | for the 2nd parameter of org.eclipse.che.api.workspace.server.WorkspaceRuntimes.<init>(WorkspaceRuntimes.java:130)
  | at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.class(WorkspaceRuntimes.java:103)
  | while locating org.eclipse.che.api.workspace.server.WorkspaceRuntimes
  | for the 2nd parameter of org.eclipse.che.multiuser.resource.api.workspace.LimitsCheckingWorkspaceManager.<init>(LimitsCheckingWorkspaceManager.java:86)
  | at org.eclipse.che.multiuser.resource.api.workspace.LimitsCheckingWorkspaceManager.class(LimitsCheckingWorkspaceManager.java:86)
  | while locating org.eclipse.che.multiuser.resource.api.workspace.LimitsCheckingWorkspaceManager
  | while locating org.eclipse.che.api.workspace.server.WorkspaceManager
  | 1 error
  | at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
  | at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:184)
  | at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
  | at com.google.inject.Guice.createInjector(Guice.java:99)
  | at org.everrest.guice.servlet.EverrestGuiceContextListener.getInjector(EverrestGuiceContextListener.java:140)
  | at com.google.inject.servlet.GuiceServletContextListener.contextInitialized(GuiceServletContextListener.java:47)
  | at org.everrest.guice.servlet.EverrestGuiceContextListener.contextInitialized(EverrestGuiceContextListener.java:85)
  | at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4727)
  | at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5189)
  | at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
  | at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:752)
  | at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:728)
  | at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:734)
  | at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:952)
  | at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1823)
  | at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  | at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  | at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  | at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  | at java.lang.Thread.run(Thread.java:748)
  | Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/wrong-role/services/che-host. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked..
  | at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:320)
  | at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:267)
  | at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:239)
  | at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:232)
  | at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleGet(OperationSupport.java:228)
  | at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleGet(BaseOperation.java:711)
  | at io.fabric8.kubernetes.client.dsl.base.BaseOperation.get(BaseOperation.java:192)
  | at org.eclipse.che.plugin.openshift.client.OpenShiftConnector.retrieveApiEndpoint(OpenShiftConnector.java:303)
  | at org.eclipse.che.plugin.openshift.client.OpenShiftConnector.getApiEndpoint(OpenShiftConnector.java:347)
  | at org.eclipse.che.plugin.docker.machine.ApiEndpointEnvVariableProvider.get(ApiEndpointEnvVariableProvider.java:40)
  | at org.eclipse.che.plugin.docker.machine.ApiEndpointEnvVariableProvider.get(ApiEndpointEnvVariableProvider.java:25)
  | at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:81)
  | at com.google.inject.internal.BoundProviderFactory.provision(BoundProviderFactory.java:72)
  | at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:61)
  | at com.google.inject.internal.BoundProviderFactory.get(BoundProviderFactory.java:62)
  | at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019)
  | at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
  | at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015)
  | at com.google.inject.multibindings.Multibinder$RealMultibinder.get(Multibinder.java:375)
  | at com.google.inject.multibindings.Multibinder$RealMultibinder.get(Multibinder.java:258)
  | at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:81)
  | at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:53)
  | at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:61)
  | at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:45)
  | at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
  | at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
  | at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
  | at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
  | at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
  | at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:56)
  | at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
  | at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
  | at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
  | at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
  | at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
  | at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
  | at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
  | at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
  | at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
  | at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
  | at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
  | at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
  | at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
  | at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
  | at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
  | at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
  | at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
  | at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
  | at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
  | at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
  | at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
  | at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
  | at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
  | at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
  | at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
  | at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:56)
  | at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:205)
  | at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:199)
  | at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085)
  | at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:199)
  | at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:180)
  | ... 18 common frames omitted
  | 2017-11-09 13:09:27,953[ost-startStop-1]  [ERROR] [o.a.c.c.C.[.[.[/wsmaster] 4733]      - Exception sending context initialized event to listener instance of class org.eclipse.che.everrest.ServerContainerInitializeListener
  | java.lang.NullPointerException: null
  | at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:770)
  | at org.everrest.core.impl.RequestDispatcher.<init>(RequestDispatcher.java:84)
  | at org.eclipse.che.everrest.ServerContainerInitializeListener.getEverrestProcessor(ServerContainerInitializeListener.java:195)
  | at org.eclipse.che.everrest.ServerContainerInitializeListener.createWsServerEndpointConfig(ServerContainerInitializeListener.java:137)
  | at org.eclipse.che.everrest.ServerContainerInitializeListener.contextInitialized(ServerContainerInitializeListener.java:96)
  | at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4727)
  | at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5189)
  | at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
  | at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:752)
  | at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:728)
  | at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:734)
  | at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:952)
  | at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1823)
  | at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  | at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  | at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  | at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  | at java.lang.Thread.run(Thread.java:748)
  | 2017-11-09 13:09:27,954[ost-startStop-1]  [ERROR] [o.a.c.core.StandardContext 5190]     - One or more listeners failed to start. Full details will be found in the appropriate container log file


```