### PR TITLE
Revert "Temporary removing PVC due to infrastructure problem"

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -26,6 +26,18 @@ objects:
     selector:
       app: che
 - apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: che
+    name: che-data-volume
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
@@ -263,7 +275,14 @@ objects:
               memory: 600Mi
             requests:
               memory: 256Mi
+          volumeMounts:
+          - mountPath: /data
+            name: che-data-volume
         serviceAccountName: che
+        volumes:
+        - name: che-data-volume
+          persistentVolumeClaim:
+            claimName: che-data-volume
     triggers:
     - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
### What does this PR do?
This reverts commit d344377bbb7187d3d3155e72b2d728b6b577697d.

Adds che-server pvc back

### What issues does this PR fix or reference?
Merging must be postponed till infra PVC issue is fixed

> Error from server (Forbidden): persistentvolumeclaims "che-data-volume" is forbidden: exceeded quota: persistent-volume, requested: requests.storage=1Gi, used: requests.storage=102376Mi, limited: requests.storage=100Gi

https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/689