### PR TITLE
Install 32bit OpenJDK over 64bit.

### DIFF
--- a/dockerfiles/che-fabric8/Dockerfile
+++ b/dockerfiles/che-fabric8/Dockerfile
@@ -6,6 +6,11 @@
 
 FROM eclipse/che-server:local
 
+# Install 32bit OpenJDK, remove 64bit version.
+RUN yum install -y java-1.8.0-openjdk.i686 && \
+    yum erase -y java-1.8.0-openjdk-headless.x86_64 && \
+    yum clean all
+
 # Install pcp - collection basics
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo


### PR DESCRIPTION
This PR prepares the che-server image to have a 32 bit OpenJDK installed.
In addition to https://github.com/fabric8-services/fabric8-tenant-che/pull/69/ it will
reduce the VmRSS size of the che-server by about 25%

My testing showed that the VmRSS of the JVM levels off at about 240-250MB from
about 335MB of 64bit OpenJDK.