### PR TITLE
Fixing local_docker_create_images_and_tag.sh script with right location of cico scripts

### DIFF
--- a/dev-scripts/local_docker_create_images_and_tag.sh
+++ b/dev-scripts/local_docker_create_images_and_tag.sh
@@ -9,7 +9,7 @@ export DeveloperBuild="true"
 
 currentDir=$(pwd)
 
-cd $(dirname "$0")/..
+cd $(dirname "$0")/../.ci/
 
 bash .ci/cico_do_docker_build_tag_push.sh
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
### What does this PR do?

Porting [1] from master to multi-tenant branch 

[1] https://github.com/redhat-developer/rh-che/commit/04230c85c9d7020a8671a94005ac46f819d9a157

### Issue:

https://github.com/redhat-developer/rh-che/issues/440#issuecomment-349394313