### PR TITLE
JSON logback configuration (#312)

### DIFF
--- a/assembly/assembly-main/src/assembly/base-component.xml
+++ b/assembly/assembly-main/src/assembly/base-component.xml
@@ -44,11 +44,16 @@
                 <exclude>**/tomcat/webapps/swagger.war</exclude>
                 <exclude>**/tomcat/webapps/docs.war</exclude>
                 <exclude>**/stacks/stacks.json</exclude>
+                <exclude>**/tomcat/conf/tomcat-logger.xml</exclude>
             </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/stacks/</directory>
             <outputDirectory>stacks/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>src/assembly/conf</directory>
+            <outputDirectory>tomcat/conf/</outputDirectory>
         </fileSet>
     </fileSets>
 </component>

--- a/assembly/assembly-main/src/assembly/conf/logback-additional-appenders.xml
+++ b/assembly/assembly-main/src/assembly/conf/logback-additional-appenders.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="file-json" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${che.logs.dir}/logs/catalina.log.json</file>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+          <level>info</level>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log.json</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>identity_id</includeMdcKeyName>
+            <includeMdcKeyName>req_id</includeMdcKeyName>
+        </encoder>
+    </appender>
+    
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>identity_id</includeMdcKeyName>
+            <includeMdcKeyName>req_id</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="file-json"/>
+    </root>
+</included>

--- a/assembly/assembly-main/src/assembly/conf/tomcat-logger.xml
+++ b/assembly/assembly-main/src/assembly/conf/tomcat-logger.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<configuration>
+    <contextListener class="org.apache.juli.logging.ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <property name="max.retention.days" value="60" />
+
+    <jmxConfigurator/>
+
+    <appender name="file" class="org.apache.juli.logging.ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${che.logs.dir}/logs/catalina.log</file>
+        <append>true</append>
+        <encoder>
+            <charset>utf-8</charset>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="org.apache.juli.logging.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+            <maxFileSize>20MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+
+   <logger name="org.apache.catalina.loader" level="OFF"/>
+    <logger name="org.apache.catalina.session.PersistentManagerBase" level="OFF"/>
+    <logger name="org.apache.jasper.servlet.TldScanner" level="OFF"/>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="file"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### What does this PR do?
Use logback logstash/json encoder for the standard output

### What issues does this PR fix or reference?
#312

### How have you tested this PR?
- use che version 5.22.0-SNAPSHOT in pom.xml and deploy in minishift and see logs in json in the log section of the che-server pod
- then I couldn't test the request_id and identity_id with minishift as somehow i have keycloack authentication issue