### PR TITLE
[che-server] Tune OpenJDK JVM flags so as to use less memory.

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -287,7 +287,7 @@ objects:
             timeoutSeconds: 60
           resources:
             limits:
-              memory: 600Mi
+              memory: 512Mi
             requests:
               memory: 256Mi
           volumeMounts:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -24,7 +24,7 @@ data:
   enable-workspaces-autostart: "false"
   keycloak-oso-endpoint: "https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token"
   keycloak-github-endpoint: "https://auth.openshift.io/api/token?for=https://github.com"
-  che-server-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=600m -Xms256m"
+  che-server-java-opts: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"


### PR DESCRIPTION
### What does this PR do?
Porting 
https://github.com/fabric8-services/fabric8-tenant-che/commit/eccec4c622d174ceb5600b247021d08a0fb57a83 to multi-tenant che-server

Gitlab issue https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/945
