### PR TITLE
Updated the ping threshold to 25

### DIFF
--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -40,4 +40,4 @@ data:
   che-keycloak-auth-server-url: "https://sso.openshift.io/auth"
   che-keycloak-realm: "fabric8"
   che-keycloak-client-id: "openshiftio-public"
-  che-wsagent-ping-success-threshold: "10"
+  che-wsagent-ping-success-threshold: "25"


### PR DESCRIPTION
### What does this PR do?
Update the config to make Che wait for 50 seconds after the first successful ping to the wsagent before continuing with the workspace bootstrap.

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/1599#issuecomment-350675000
https://github.com/fabric8-services/fabric8-tenant-che/pull/92

### How have you tested this PR?
I have tried different value (10, 15, 20 and 25) and only with 25 I had 10 successful workspace creations in a raw on osio.
