### PR TITLE
rh-che #226: adding 'CHE_LIMITS_USER_WORKSPACES_RUN_COUNT' in order to limit number of running workspaces that a single user is allowed to have on osio

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -268,6 +268,11 @@ objects:
               configMapKeyRef:
                 key: che-wsagent-ping-success-threshold
                 name: che
+          - name: CHE_LIMITS_USER_WORKSPACES_RUN_COUNT
+            valueFrom:
+              configMapKeyRef:
+                key: che-limits-user-workspaces-run-count
+                name: che
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -41,3 +41,4 @@ data:
   che-keycloak-realm: "fabric8"
   che-keycloak-client-id: "openshiftio-public"
   che-wsagent-ping-success-threshold: "2"
+  che-limits-user-workspaces-run-count: "1"


### PR DESCRIPTION
### What does this PR do?
adding 'CHE_LIMITS_USER_WORKSPACES_RUN_COUNT' in order to limit number of running workspaces that a single user is allowed to have on osio

```
#     The maximum number of running workspaces that a single user is allowed to have.
#     If the user has reached this threshold and they try to start an additional
#     workspace, they will be prompted with an error message. The user will need to
#     stop a running workspace to activate another.
#CHE_LIMITS_USER_WORKSPACES_RUN_COUNT=-1
```
https://github.com/eclipse/che/blob/master/dockerfiles/init/manifests/che.env#L541-L545

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/226
gitlab issue  https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/997

### How have you tested this PR?

Not tested - the plan is:
1. update cm on prod / prod - preview
2. merge PR and test on prod-preview
3. manually promote to prod
