### PR TITLE
Allow deploying multi-tenant rh-che on Minishift in single-tenant mode

### DIFF
--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserBasedWorkspacesRoutingSuffixProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserBasedWorkspacesRoutingSuffixProvider.java
@@ -38,21 +38,28 @@ public class UserBasedWorkspacesRoutingSuffixProvider extends WorkspacesRoutingS
       LoggerFactory.getLogger(UserBasedWorkspacesRoutingSuffixProvider.class);
 
   private String cheWorkspacesRoutingSuffix;
+  private boolean fabric8CheMultitenant;
 
   @Inject private Fabric8WorkspaceEnvironmentProvider workspaceEnvironmentProvider;
 
   @Inject
   public UserBasedWorkspacesRoutingSuffixProvider(
+      @Named("che.fabric8.multitenant") boolean fabric8CheMultitenant,
       @Nullable @Named("che.fabric8.workspaces.routing_suffix") String cheWorkspacesRoutingSuffix) {
 
     LOG.info("Workspaces Routing Suffix = {}", cheWorkspacesRoutingSuffix);
     this.cheWorkspacesRoutingSuffix =
         "NULL".equals(cheWorkspacesRoutingSuffix) ? null : cheWorkspacesRoutingSuffix;
+    this.fabric8CheMultitenant = fabric8CheMultitenant;
   }
 
   @Override
   @Nullable
   public String get() {
+    if (!fabric8CheMultitenant) {
+      return super.get();
+    }
+
     UserCheTenantData userCheTenantData;
     try {
       userCheTenantData = workspaceEnvironmentProvider.getUserCheTenantData();


### PR DESCRIPTION
### What does this PR do?

Allow deploying multi-tenant rh-che on Minishift in single-tenant mode, thus usng the default mechanism of creating workspace PODs in the Che server OS namespace.

### What issues does this PR fix or reference?

This is part of the fix for issue
https://github.com/redhat-developer/rh-che/issues/489

### How have you tested this PR?

Yes, partly though I had Minishift problems at the end that prevented me testing a last time just before pushing.
