### PR TITLE
osio-1864: Changing cm 'workspaces-memory-limit' to 2400Mi instead of 2.4Gi (which according to the above is buggy/not recommended)

### DIFF
--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -19,7 +19,7 @@ data:
   port: "8080"
   remote-debugging-enabled: "false"
   che-oauth-github-forceactivation: "true"
-  workspaces-memory-limit: "2.4Gi"
+  workspaces-memory-limit: "2400Mi"
   workspaces-memory-request: "1100Mi"
   enable-workspaces-autostart: "false"
   keycloak-oso-endpoint: "https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token"


### PR DESCRIPTION
osio issue - https://github.com/openshiftio/openshift.io/issues/1864
