### PR TITLE
Use eclipse/che version 5.22.1 for the MT `rh-che`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>5.22.0</version>
+        <version>5.22.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>
