### PR TITLE
openshift.io #2122: Adding validation for 'UserCheTenantData' obtained from 'api/user/services' endpoint payload

### DIFF
--- a/plugins/fabric8-multi-tenant-manager/pom.xml
+++ b/plugins/fabric8-multi-tenant-manager/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -162,6 +162,7 @@ public class Fabric8WorkspaceEnvironmentProvider extends OpenshiftWorkspaceEnvir
           String osoProxyUrl = multiClusterOpenShiftProxy.getUrl();
 
           UserCheTenantData cheTenantData = new UserCheTenantData(name, osoProxyUrl, suffix);
+          UserCheTenantDataValidator.validate(cheTenantData);
           LOG.info("cheTenantData = {}", cheTenantData);
           return cheTenantData;
         }

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserCheTenantDataValidator.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/UserCheTenantDataValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.multitenant;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class UserCheTenantDataValidator {
+  private static final Logger LOG = LoggerFactory.getLogger(UserCheTenantDataValidator.class);
+
+  private UserCheTenantDataValidator() {}
+
+  public static void validate(final UserCheTenantData data) {
+    if (data == null) {
+      LOG.error("'UserCheTenantData' can not be null");
+      throw new NullPointerException("'UserCheTenantData' can not be null");
+    } else if (StringUtils.isBlank(data.getClusterUrl())) {
+      LOG.error("'ClusterUrl' can not be blank: {}", data);
+      throw new IllegalArgumentException("'ClusterUrl' can not be blank");
+    } else if (StringUtils.isBlank(data.getRouteBaseSuffix())) {
+      LOG.error("'RouteBaseSuffix' can not be blank: {}", data);
+      throw new IllegalArgumentException("'RouteBaseSuffix' can not be blank");
+    } else if (StringUtils.isBlank(data.getNamespace())) {
+      LOG.error("'Namespace' can not be blank: {}", data);
+      throw new IllegalArgumentException("'Namespace' can not be blank");
+    }
+  }
+}


### PR DESCRIPTION

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
openshift.io #2122: Adding validation for 'UserCheTenantData' obtained from 'api/user/services' endpoint payload

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/2122

