### PR TITLE
rh-che #532: Adding unleash java client 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>
+        <unleash.client.java.version>3.0.0</unleash.client.java.version>
         <withoutDashboard>false</withoutDashboard>
     </properties>
     <dependencyManagement>
@@ -107,6 +108,12 @@
                 <groupId>com.redhat.che</groupId>
                 <artifactId>ls-bayesian-agent</artifactId>
                 <version>${rh.che.plugins.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>no.finn.unleash</groupId>
+                <artifactId>unleash-client-java</artifactId>
+                <version>${unleash.client.java.version}</version>
                 <type>jar</type>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What does this PR do?
Adding unleash java client 3.0.0

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/532

`mvn dependecy:tree`
```
[INFO] |  +- no.finn.unleash:unleash-client-java:jar:3.0.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.1:compile
[INFO] |  |  \- com.sangupta:murmur:jar:1.0.0:compile
```

