### PR TITLE
rh-che #532: Adding service.account.id / service.account.secret as env vars to openshift template

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -263,6 +263,16 @@ objects:
               secretKeyRef:
                   key: che.jdbc.username
                   name: che
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
+            valueFrom:
+              secretKeyRef:
+                  key: service.account.secret
+                  name: che
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                  key: service.account.id
+                  name: che
           - name: CHE_WORKSPACE_AGENT_DEV_PING__SUCCESS__THRESHOLD
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
### What does this PR do?
Adding service.account.id / service.account.secret as env vars to openshift template

### What issues does this PR fix or reference?
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1222#note_264499
#532 

