### PR TITLE
Changing resources names / labels to rhche for che6 deployment on prod / prod-preview osd

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -2,21 +2,21 @@ kind: Template
 apiVersion: v1
 metadata:
   labels:
-    app: che
-  name: che
+    app: rhche
+  name: rhche
 objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
-      app: che
-    name: che
+      app: rhche
+    name: rhche
 - apiVersion: v1
   kind: Service
   metadata:
     labels:
-      app: che
-    name: che-host
+      app: rhche
+    name: rhche-host
   spec:
     ports:
     - name: http
@@ -24,13 +24,13 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      app: che
+      app: rhche
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     labels:
-      app: che
-    name: che-data-volume
+      app: rhche
+    name: rhche-data-volume
   spec:
     accessModes:
     - ReadWriteOnce
@@ -41,13 +41,13 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      app: che
-    name: che
+      app: rhche
+    name: rhche
   spec:
     replicas: 1
     revisionHistoryLimit: 2
     selector:
-      app: che
+      app: rhche
     strategy:
       recreateParams:
         timeoutSeconds: 10000
@@ -55,7 +55,7 @@ objects:
     template:
       metadata:
         labels:
-          app: che
+          app: rhche
       spec:
         containers:
         - env:
@@ -63,22 +63,22 @@ objects:
             valueFrom:
               configMapKeyRef:
                 key: che-host
-                name: che
+                name: rhche
           - name: CHE_WORKSPACE_STORAGE
             valueFrom:
               configMapKeyRef:
                 key: workspace-storage
-                name: che
+                name: rhche
           - name: CHE_LOGS_DIR
             valueFrom:
               configMapKeyRef:
                 key: che.logs.dir
-                name: che
+                name: rhche
           - name: CHE_LOCAL_CONF_DIR
             valueFrom:
               configMapKeyRef:
                 key: local-conf-dir
-                name: che
+                name: rhche
           - name: CHE_INFRA_OPENSHIFT_PROJECT
             valueFrom:
               fieldRef:
@@ -87,137 +87,137 @@ objects:
             valueFrom:
               configMapKeyRef:
                 key: che.predefined.stacks.reload_on_start
-                name: che
+                name: rhche
           - name: CHE_LOG_LEVEL
             valueFrom:
               configMapKeyRef:
                 key: log-level
-                name: che
+                name: rhche
           - name: CHE_PORT
             valueFrom:
               configMapKeyRef:
                 key: port
-                name: che
+                name: rhche
           - name: CHE_DEBUG_SERVER
             valueFrom:
               configMapKeyRef:
                 key: remote-debugging-enabled
-                name: che
+                name: rhche
           - name: CHE_LIMITS_WORKSPACE_ENV_RAM
             valueFrom:
               configMapKeyRef:
                 key: workspaces-memory-limit-max
-                name: che
+                name: rhche
           - name: CHE_WORKSPACE_DEFAULT__MEMORY__MB
             valueFrom:
               configMapKeyRef:
                 key: workspaces-memory-limit
-                name: che
+                name: rhche
           - name: CHE_WORKSPACE_AUTO__START
             valueFrom:
               configMapKeyRef:
                 key: enable-workspaces-autostart
-                name: che
+                name: rhche
           - name: JAVA_OPTS
             valueFrom:
               configMapKeyRef:
                 key: che-server-java-opts
-                name: che
+                name: rhche
           - name: CHE_WORKSPACE_JAVA__OPTIONS
             valueFrom:
               configMapKeyRef:
                 key: che-workspaces-java-opts
-                name: che
+                name: rhche
           - name: CHE_INFRA_OPENSHIFT_TLS__ENABLED
             valueFrom:
               configMapKeyRef:
                 key: che-openshift-secure-routes
-                name: che
+                name: rhche
           - name: CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS
             valueFrom:
               configMapKeyRef:
                 key: che-openshift-precreate-subpaths
-                name: che
+                name: rhche
           - name: CHE_KEYCLOAK_GITHUB_ENDPOINT
             valueFrom:
               configMapKeyRef:
                 key: keycloak-github-endpoint
-                name: che
+                name: rhche
           - name: CHE_FABRIC8_MULTITENANT
             valueFrom:
               configMapKeyRef:
                 key: che-fabric8-multitenant
-                name: che
+                name: rhche
           - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
             valueFrom:
               configMapKeyRef:
                 key: che-fabric8-user-service-endpoint
-                name: che
+                name: rhche
           - name: CHE_FABRIC8_AUTH_ENDPOINT
             valueFrom:
               configMapKeyRef:
                 key: che-fabric8-auth-endpoint
-                name: che
+                name: rhche
           - name: CHE_FABRIC8_MULTICLUSTER_OSO_PROXY_URL
             valueFrom:
               configMapKeyRef:
                 key: che-fabric8-multicluster-oso-proxy-url
-                name: che
+                name: rhche
           - name: CHE_DOCKER_ENABLE__CONTAINER__STOP__DETECTOR
             valueFrom:
               configMapKeyRef:
                 key: che-docker-enable-container-stop-detector
-                name: che
+                name: rhche
           - name: CHE_API
             valueFrom:
               configMapKeyRef:
                 key: che-api
-                name: che
+                name: rhche
           - name: CHE_WEBSOCKET_ENDPOINT
             valueFrom:
               configMapKeyRef:
                 key: che-websocket-endpoint
-                name: che
+                name: rhche
           - name: CHE_WORKSPACE_LOGS_ROOT__DIR
             valueFrom:
               configMapKeyRef:
                 key: che-workspace-logs
-                name: che
+                name: rhche
           - name: CHE_KEYCLOAK_AUTH__SERVER__URL
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-auth-server-url
-                name: che
+                name: rhche
           - name: CHE_KEYCLOAK_REALM
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-realm
-                name: che
+                name: rhche
           - name: CHE_KEYCLOAK_CLIENT__ID
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-client-id
-                name: che
+                name: rhche
           - name: CHE_HOST
             valueFrom:
               configMapKeyRef:
                 key: che-host
-                name: che
+                name: rhche
           - name: CHE_JDBC_PASSWORD
             valueFrom:
               secretKeyRef:
                   key: che.jdbc.password
-                  name: che
+                  name: rhche
           - name: CHE_JDBC_URL
             valueFrom:
               secretKeyRef:
                   key: che.jdbc.url
-                  name: che
+                  name: rhche
           - name: CHE_JDBC_USERNAME
             valueFrom:
               secretKeyRef:
                   key: che.jdbc.username
-                  name: che
+                  name: rhche
           - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
             valueFrom:
               secretKeyRef:
@@ -232,39 +232,39 @@ objects:
             valueFrom:
               configMapKeyRef:
                 key: che-workspace-server-ping-success-threshold
-                name: che
+                name: rhche
           - name: CHE_LIMITS_USER_WORKSPACES_RUN_COUNT
             valueFrom:
               configMapKeyRef:
                 key: che-limits-user-workspaces-run-count
-                name: che
+                name: rhche
           - name: CHE_INFRASTRUCTURE_ACTIVE
             value: "openshift"
           - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
             valueFrom:
               configMapKeyRef:
                 key: infra-bootstrapper-binary-url
-                name: che
+                name: rhche
           - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
             valueFrom:
               configMapKeyRef:
                 key: infra-machine-start-timeout
-                name: che
+                name: rhche
           - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
             valueFrom:
               configMapKeyRef:
                 key: infra-pvc-strategy
-                name: che
+                name: rhche
           - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
             valueFrom:
               configMapKeyRef:
                 key: infra-trust-certs
-                name: che
+                name: rhche
           - name: CHE_MULTIUSER
             valueFrom:
               configMapKeyRef:
                 key: multi-user
-                name: che
+                name: rhche
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -274,7 +274,7 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 120
             timeoutSeconds: 10
-          name: che
+          name: rhche
           ports:
           - containerPort: 8080
             name: http
@@ -294,29 +294,29 @@ objects:
               memory: 256Mi
           volumeMounts:
           - mountPath: /data
-            name: che-data-volume
-        serviceAccountName: che
+            name: rhche-data-volume
+        serviceAccountName: rhche
         volumes:
-        - name: che-data-volume
+        - name: rhche-data-volume
           persistentVolumeClaim:
-            claimName: che-data-volume
+            claimName: rhche-data-volume
     triggers:
     - type: ConfigChange
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      app: che
-    name: che
+      app: rhche
+    name: rhche
   spec:
     tls:
       insecureEdgeTerminationPolicy: Redirect
       termination: edge
     to:
       kind: Service
-      name: che-host
+      name: rhche-host
 parameters:
 - name: IMAGE
-  value: rhche/che-server
+  value: rhche/rhche-server
 - name: IMAGE_TAG
   value: latest

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: che
+  name: rhche
 type: Opaque
 data:
   infra-bootstrapper-binary-url: "https://che.prod-preview.openshift.io/agent-binaries/linux_amd64/bootstrapper/bootstrapper"


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Changing resources names / labels to rhche for che6 deployment on prod / prod-preview osd

### What issues does this PR fix or reference?
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1351

### How have you tested this PR?
Not tested

NOTE: `service.account.secret / service.account.id` were not updated to `rhche` deliberately since they would be missing from the begging. New housekeeping issue should be created once `rhche` secret would be available for porting those values from `che` secret