### PR TITLE
Changing image from 'che-multiuser' to 'rh-che-server' for che 6 deployment on osd

### DIFF
--- a/.ci/cico_deploy.sh
+++ b/.ci/cico_deploy.sh
@@ -48,8 +48,8 @@ else
   exit 1
 fi
 
-PROD_IMAGE_DEVSHIFT="push.registry.devshift.net/che/che-multiuser:${TAG_SHORT_COMMIT_HASH}"
-PROD_IMAGE_DEVSHIFT_LATEST="push.registry.devshift.net/che/che-multiuser:latest"
+PROD_IMAGE_DEVSHIFT="push.registry.devshift.net/che/rh-che-server:${TAG_SHORT_COMMIT_HASH}"
+PROD_IMAGE_DEVSHIFT_LATEST="push.registry.devshift.net/che/rh-che-server:latest"
 
 if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
   docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" push.registry.devshift.net

--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 # Config used by the different scripts
 
 export RH_CHE_GIT_REPO=https://github.com/redhat-developer/rh-che
-export RH_CHE_GIT_BRANCH=multi-tenant-che6
+export RH_CHE_GIT_BRANCH=rh-che6
 
 export NPM_CONFIG_PREFIX=~/.che_node_modules
 export PATH=$NPM_CONFIG_PREFIX/bin:$PATH


### PR DESCRIPTION
### What does this PR do?
Changing image from 'che-multiuser' to 'rh-che-server' for che 6 deployment on osd

### What issues does this PR fix or reference?
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1351