### PR TITLE
Restore the GitHub token injection for Che 6 on OSIO

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -76,6 +76,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>repack</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                      <goal>run</goal>
+                    </goals>
+                    <configuration>
+                      <target>
+                        <!-- note that here we reference previously declared dependency -->
+                        <unzip src="${org.eclipse.che.multiuser:che-multiuser-keycloak-server:jar}" dest="${project.build.directory}/tmpKeycloakModule"/>
+                        <delete file="${project.build.directory}/tmpKeycloakModule/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakModule.class"/> 
+                        <!-- now do what you need to any of unpacked files under target/tmp/ -->
+                        <zip basedir="${project.build.directory}/tmpKeycloakModule" destfile="${project.build.directory}/${project.build.finalName}/WEB-INF/lib/che-multiuser-keycloak-server-rhche-${che.version}.jar"/>
+                        <!-- now the modified jar is available  -->
+                      </target>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>            <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-dynamodule-maven-plugin</artifactId>
                 <executions>
@@ -101,7 +123,7 @@
                             <type>war</type>
                         </overlay>
                     </overlays>
-                    <packagingExcludes>WEB-INF/lib/che-core-ide-stacks-${che.version}.jar,
+                    <packagingExcludes>WEB-INF/lib/che-multiuser-keycloak-server-${che.version}.jar,
                         WEB-INF/lib/che-core-ide-stacks-${che.version}.jar,
                         WEB-INF/classes/che-in-che.json</packagingExcludes>
                 </configuration>

--- a/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
@@ -21,6 +21,9 @@ import org.eclipse.che.security.oauth.OAuthAuthenticator;
 public class Fabric8WsMasterModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(org.eclipse.che.security.oauth.shared.OAuthTokenProvider.class)
+        .to(org.eclipse.che.security.oauth.OAuthAuthenticatorTokenProvider.class);
+    bind(org.eclipse.che.security.oauth.OAuthAuthenticationService.class);
     Multibinder<OAuthAuthenticator> oAuthAuthenticators =
         Multibinder.newSetBinder(binder(), OAuthAuthenticator.class);
     oAuthAuthenticators.addBinding().to(OpenShiftGitHubOAuthAuthenticator.class);

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.keycloak.server.deploy;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.user.server.TokenValidator;
+import org.eclipse.che.api.user.server.spi.ProfileDao;
+import org.eclipse.che.multiuser.keycloak.server.KeycloakConfigurationService;
+import org.eclipse.che.multiuser.keycloak.server.KeycloakTokenValidator;
+import org.eclipse.che.multiuser.keycloak.server.dao.KeycloakProfileDao;
+
+public class KeycloakModule extends AbstractModule {
+  @Override
+  protected void configure() {
+
+    bind(HttpJsonRequestFactory.class)
+        .to(org.eclipse.che.multiuser.keycloak.server.KeycloakHttpJsonRequestFactory.class);
+    bind(TokenValidator.class).to(KeycloakTokenValidator.class);
+    bind(KeycloakConfigurationService.class);
+
+    bind(ProfileDao.class).to(KeycloakProfileDao.class);
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Restore the GitHub token injection ability for Che 6 on OSIO, which was disabled and replaced by Keycloak specific linked account management in upstream Che 6 multi-user.

### What issues does this PR fix or reference?

https://github.com/redhat-developer/rh-che/issues/615

### How have you tested this PR?

Yes, the involved rest endpoints were tested manually on dev-cluster.