### PR TITLE
Add Sentry logger to get notification about bugs in RhChe

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -34,6 +34,14 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-logback</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
@@ -57,6 +65,8 @@
                                 <!-- dependency is required just to overlay it's content -->
                                 <dep>com.redhat.che:fabric8-ide-gwt-app</dep>
                                 <dep>net.logstash.logback:logstash-logback-encoder</dep>
+                                <dep>io.sentry:sentry</dep>
+                                <dep>io.sentry:sentry-logback</dep>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/assembly/assembly-main/src/assembly/base-component.xml
+++ b/assembly/assembly-main/src/assembly/base-component.xml
@@ -49,5 +49,9 @@
             <directory>${project.build.directory}/stacks/</directory>
             <outputDirectory>stacks/</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>src/assembly/conf</directory>
+            <outputDirectory>tomcat/conf/</outputDirectory>
+        </fileSet>
     </fileSets>
 </component>

--- a/assembly/assembly-main/src/assembly/conf/logback-additional-appenders.xml
+++ b/assembly/assembly-main/src/assembly/conf/logback-additional-appenders.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2016-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${CHE_LOGS_SENTRY_LEVEL:-WARN}</level>
+        </filter>
+    </appender>
+
+    <root>
+        <appender-ref ref="Sentry"/>
+    </root>
+</included>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -28,6 +28,14 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.redhat.che</groupId>
             <artifactId>fabric8-ide-stacks</artifactId>
         </dependency>
@@ -38,6 +46,14 @@
         <dependency>
             <groupId>com.redhat.che</groupId>
             <artifactId>ls-bayesian-agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-logback</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che</groupId>
@@ -51,12 +67,36 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-keycloak-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-keycloak-token-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-github-oauth2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
@@ -97,7 +137,8 @@
                     </configuration>
                   </execution>
                 </executions>
-              </plugin>            <plugin>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-dynamodule-maven-plugin</artifactId>
                 <executions>
@@ -135,7 +176,12 @@
                     <execution>
                         <id>analyze</id>
                         <configuration>
-                            <skip>true</skip>
+                            <ignoredUnusedDeclaredDependencies>
+                                <dep>io.sentry:sentry</dep>
+                                <dep>io.sentry:sentry-logback</dep>
+                                <dep>com.redhat.che:fabric8-ide-stacks</dep>
+                                <dep>org.eclipse.che.multiuser:che-multiuser-keycloak-server</dep>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -275,6 +275,28 @@ objects:
               configMapKeyRef:
                 key: logs-encoding
                 name: rhche
+          - name: CHE_LOGS_SENTRY_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                key: che-logs-sentry-level
+                name: rhche
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                key: che-logs-sentry-dsn
+                name: rhche
+          - name: SENTRY_STACKTRACE_APP_PACKAGES
+            valueFrom:
+              configMapKeyRef:
+                key: sentry-stacktrace-app-packages
+                name: rhche
+          - name: SENTRY_ENVIRONMENT
+            valueFrom:
+              configMapKeyRef:
+                key: sentry-environment
+                name: rhche
+          - name: SENTRY_RELEASE
+            value: ${IMAGE_TAG}
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -42,3 +42,7 @@ data:
   che-limits-user-workspaces-run-count: "1"
   che.workspace.agent.dev.inactive_stop_timeout_ms: "1800000"
   logs-encoding: "json"
+  che-logs-sentry-level: 'WARN'
+  che-logs-sentry-dsn: 'NULL'
+  sentry-stacktrace-app-packages: 'com.redhat,org.eclipse.che'
+  sentry-environment: 'dev'

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>
+        <sentry.version>1.7.2</sentry.version>
         <unleash.client.java.version>3.0.0</unleash.client.java.version>
         <withoutDashboard>false</withoutDashboard>
     </properties>
@@ -109,6 +110,16 @@
                 <artifactId>ls-bayesian-agent</artifactId>
                 <version>${rh.che.plugins.version}</version>
                 <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>${sentry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-logback</artifactId>
+                <version>${sentry.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.finn.unleash</groupId>


### PR DESCRIPTION
### What does this PR do?
In the WIP state because it is based on #616 and should be updated after the merge of #616.
Adds a logger that sends error and warn logs to Sentry.
Allows changing the level of logs that will be sent to sentry with an env var CHE_LOGS_SENTRY_LEVEL. The default is `WARN`.
To use setup values of variables in config map:
`SENTRY_ENVIRONMENT` - prod, prod-preview, dev
`SENTRY_DSN` - get from Sentry.
Also:
Explicitly add dependencies that were transient and didn't
produce errors because dependency analyzer was disabled.
Enabled dependency analyzer for API war.
Add env var SENTRY_RELEASE that points to Che master image tag to
identify the version of the project that produced a bug (CI uses Git
commit hash as the image tag).

### What issues does this PR fix or reference?
Related to https://github.com/redhat-developer/rh-che/issues/624
Related to https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1686
Related to https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1678
Fixes #612 

### How have you tested this PR?
Yes, on dev cluster.