### PR TITLE
Revert "move OS specific logic to scripts from config"

### DIFF
--- a/.ci/cico_deploy.sh
+++ b/.ci/cico_deploy.sh
@@ -9,7 +9,7 @@ set -u
 set +e
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET=${TARGET:-"centos"}
+
 # Retrieve credentials to push the image to the docker hub
 cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT > inherit-env
 . inherit-env
@@ -27,11 +27,7 @@ echo "export OSO_DOMAIN=8a09.starter-us-east-2.openshiftapps.com" >> $config_fil
 echo "export OSO_HOSTNAME=mlabuda-jenkins.8a09.starter-us-east-2.openshiftapps.com" >> $config_file
 echo "export CHE_SERVER_DOCKER_IMAGE_TAG=$CHE_SERVER_DOCKER_IMAGE_TAG" >> $config_file
 echo "export NAMESPACE=${NAMESPACE}" >> $config_file
-if [ $TARGET == "rhel" ]; then
-  export REGISTRY=${DOCKER_REGISTRY:-"push.registry.devshift.net/osio-prod"}
-else
-  export REGISTRY="push.registry.devshift.net"
-fi
+
 # Triggers update of tenant and execution of functional tests
 echo "CHE VALIDATION: Verification skipped until job devtools-che-functional-tests get fixed"
 # git clone https://github.com/redhat-developer/che-functional-tests.git

--- a/.ci/cico_do_docker_build_tag_push.sh
+++ b/.ci/cico_do_docker_build_tag_push.sh
@@ -7,7 +7,7 @@
 
 currentDir=`pwd`
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET=${TARGET:-"centos"}
+
 . ${ABSOLUTE_PATH}/../config 
 
 RH_CHE_TAG=$(git rev-parse --short HEAD)
@@ -45,13 +45,7 @@ do
 
   echo "Copying assembly ${distribution} --> ${LOCAL_ASSEMBLY_DIR}"
   cp -r "${distribution}" "${LOCAL_ASSEMBLY_DIR}"
-  if [ $TARGET == "rhel" ]; then
-    export DOCKERFILE="Dockerfile.rhel"
-    export REGISTRY=${DOCKER_REGISTRY:-"push.registry.devshift.net/osio-prod"}
-  else
-    export DOCKERFILE="Dockerfile"
-    export REGISTRY="push.registry.devshift.net"
-  fi
+
   if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
     docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" ${REGISTRY}
   else

--- a/config
+++ b/config
@@ -1,6 +1,16 @@
 # Config used by the different scripts
 
+TARGET=${TARGET:-"centos"}
+
 export NAMESPACE="rhchestage"
+
+if [ $TARGET == "rhel" ]; then
+  export DOCKERFILE="Dockerfile.rhel"
+  export REGISTRY=${DOCKER_REGISTRY:-"push.registry.devshift.net/osio-prod"}
+else
+  export DOCKERFILE="Dockerfile"
+  export REGISTRY="push.registry.devshift.net"
+fi
 
 export DOCKER_IMAGE="rh-che-server"
 


### PR DESCRIPTION
Reverts redhat-developer/rh-che#655
revert this because it was a problem with deploy rhel based che image