### PR TITLE
fix build, add dependency

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -95,6 +95,10 @@
             <artifactId>che-multiuser-keycloak-token-provider</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-personal-account</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-github-oauth2</artifactId>
         </dependency>


### PR DESCRIPTION
after recent changes build is failed on cico: https://ci.centos.org/view/Devtools/job/devtools-rh-che-build-che-credentials-rh-che6/42/console
```
[WARNING] Used undeclared dependencies found:
[WARNING]    org.eclipse.che.multiuser:che-multiuser-personal-account:jar:6.4.1:compile
[INFO] Add the following to your pom to correct the missing dependencies: 
[INFO] 
<dependency>
  <groupId>org.eclipse.che.multiuser</groupId>
  <artifactId>che-multiuser-personal-account</artifactId>
  <version>6.4.1</version>
</dependency>
```
fix build, add dependency