### PR TITLE
osio #3428: Adding `-Dvertx.disableDnsResolver=true` to vert.x run / debug commands

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -520,7 +520,7 @@
           }
         },
         {
-          "commandLine": "scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path}'",
+          "commandLine": "scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path} -Dvertx.disableDnsResolver=true'",
           "name": "run",
           "type": "custom",
           "attributes": {
@@ -529,7 +529,7 @@
           }
         },
         {
-          "commandLine": "scl enable rh-maven33 'mvn compile vertx:debug -f ${current.project.path}'",
+          "commandLine": "scl enable rh-maven33 'mvn compile vertx:debug -f ${current.project.path} -Dvertx.disableDnsResolver=true'",
           "name": "debug",
           "type": "custom",
           "attributes": {


### PR DESCRIPTION
### What does this PR do?
osio #3428: Adding `-Dvertx.disableDnsResolver=true` to vert.x run / debug commands

### What issues does this PR fix or reference?
osio issue https://github.com/openshiftio/openshift.io/issues/3428

### How have you tested this PR?
tested on osio by mnually adding flag to the commands