### PR TITLE
Using rhche secret for obtaining `service.account.id` / `service.account.secret`

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -227,12 +227,12 @@ objects:
             valueFrom:
               secretKeyRef:
                   key: service.account.secret
-                  name: che
+                  name: rhche
           - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
             valueFrom:
               secretKeyRef:
                   key: service.account.id
-                  name: che
+                  name: rhche
           - name: CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
### What does this PR do?
Using rhche secret for obtaining `service.account.id` / `service.account.secret`

### What issues does this PR fix or reference?
Gitlab issue https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1861#note_324977
opensshift.io issue https://github.com/openshiftio/openshift.io/issues/3476

### How have you tested this PR?
Not tested