### PR TITLE
Tuninng OpenJDK JVM flags for che server

### DIFF
--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -21,7 +21,7 @@ data:
   workspaces-memory-limit-max: "2400mb"
   enable-workspaces-autostart: "false"
   keycloak-github-endpoint: "https://auth.prod-preview.openshift.io/api/token?for=https://github.com"
-  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
+  che-server-java-opts: "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
   che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
   che-openshift-secure-routes: "true"
   che-secure-external-urls: "true"


### PR DESCRIPTION
### What does this PR do?
Updating `che-server-java-opts` 

### What issues does this PR fix or reference?
For some reason options set in https://github.com/redhat-developer/rh-che/pull/474 are not applied in master / prod & prod-preview osd

Related gitlab issue - https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/945

### How have you tested this PR?
Tested on minishift

Original PR - https://github.com/fabric8-services/fabric8-tenant-che/commit/eccec4c622d174ceb5600b247021d08a0fb57a83

Note: that I have not updated memory limit for che server and it still uses `750Mi`, potentially it could be reduced to `512Mi` as it was done in the original single-tenant che PR.  Not sure if it worth reducing ram since no proper stress tests have not been performed with lower limits
 