### PR TITLE
Segment/Woopra -based telemetry in OSIO Che workspaces

### DIFF
--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -25,6 +25,10 @@
     <dependencies>
         <dependency>
             <groupId>com.redhat.che</groupId>
+            <artifactId>che-plugin-analytics-wsagent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.redhat.che</groupId>
             <artifactId>che-plugin-bayesian-lang-server</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>com.redhat.che</groupId>
+            <artifactId>che-plugin-analytics-wsmaster</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.redhat.che</groupId>
             <artifactId>fabric8-ide-stacks</artifactId>
         </dependency>
         <dependency>
@@ -123,23 +127,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
-                  <execution>
-                    <id>repack</id>
-                    <phase>process-classes</phase>
-                    <goals>
-                      <goal>run</goal>
-                    </goals>
-                    <configuration>
-                      <target>
-                        <!-- note that here we reference previously declared dependency -->
-                        <unzip src="${org.eclipse.che.multiuser:che-multiuser-keycloak-server:jar}" dest="${project.build.directory}/tmpKeycloakModule"/>
-                        <delete file="${project.build.directory}/tmpKeycloakModule/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakModule.class"/> 
-                        <!-- now do what you need to any of unpacked files under target/tmp/ -->
-                        <zip basedir="${project.build.directory}/tmpKeycloakModule" destfile="${project.build.directory}/${project.build.finalName}/WEB-INF/lib/che-multiuser-keycloak-server-rhche-${che.version}.jar"/>
-                        <!-- now the modified jar is available  -->
-                      </target>
-                    </configuration>
-                  </execution>
+                    <execution>
+                        <id>repack</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- note that here we reference previously declared dependency -->
+                                <unzip dest="${project.build.directory}/tmpKeycloakModule" src="${org.eclipse.che.multiuser:che-multiuser-keycloak-server:jar}" />
+                                <delete file="${project.build.directory}/tmpKeycloakModule/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakModule.class" />
+                                <!-- now do what you need to any of unpacked files under target/tmp/ -->
+                                <zip basedir="${project.build.directory}/tmpKeycloakModule" destfile="${project.build.directory}/${project.build.finalName}/WEB-INF/lib/che-multiuser-keycloak-server-rhche-${che.version}.jar" />
+                                <!-- now the modified jar is available  -->
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
@@ -17,3 +17,7 @@ che.fabric8.user_service.endpoint=https://api.openshift.io/api/user/services
 # If the value is NULL then user token based approach is used for authentication
 che.openshift.service_account.id=NULL
 che.openshift.service_account.secret=NULL
+
+# By default disable telemetry in rh-che if it's not deployed in production or prod-preview
+che.fabric8.analytics.segment_write_key=NULL
+che.fabric8.analytics.woopra_domain=NULL

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -297,6 +297,16 @@ objects:
                 name: rhche
           - name: SENTRY_RELEASE
             value: ${IMAGE_TAG}
+          - name: CHE_FABRIC8_ANALYTICS_SEGMENT__WRITE__KEY
+            valueFrom:
+              configMapKeyRef:
+                key: analytics.segment_write_key
+                name: rhche
+          - name: CHE_FABRIC8_ANALYTICS_WOOPRA__DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                key: analytics.woopra_domain
+                name: rhche
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -46,3 +46,6 @@ data:
   che-logs-sentry-dsn: 'NULL'
   sentry-stacktrace-app-packages: 'com.redhat,org.eclipse.che'
   sentry-environment: 'dev'
+  analytics.segment_write_key: 'rIZ5NDpUfqkTNdfsBxOBcJoLDT3TxftM' 
+  analytics.woopra_domain: 'test.openshift.io'
+  

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -46,6 +46,6 @@ data:
   che-logs-sentry-dsn: 'NULL'
   sentry-stacktrace-app-packages: 'com.redhat,org.eclipse.che'
   sentry-environment: 'dev'
-  analytics.segment_write_key: 'rIZ5NDpUfqkTNdfsBxOBcJoLDT3TxftM' 
-  analytics.woopra_domain: 'test.openshift.io'
+  analytics.segment_write_key: 'NULL' 
+  analytics.woopra_domain: 'NULL'
   

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
@@ -24,20 +24,40 @@
     <name>Fabric8 IDE :: Plugins :: Segment Analytics Integration :: WsAgent part</name>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
+            <artifactId>guice-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>com.segment.analytics.java</groupId>
             <artifactId>analytics</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.segment.analytics.java</groupId>
+            <artifactId>analytics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-languageserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-languageserver-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -48,16 +68,27 @@
             <artifactId>che-core-workspace-activity-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-json-server</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -76,20 +107,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
@@ -14,7 +14,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>fabric8-ide-plugins-parent</artifactId>
+        <artifactId>che-plugin-analytics</artifactId>
         <groupId>com.redhat.che</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2016-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>fabric8-ide-plugins-parent</artifactId>
+        <groupId>com.redhat.che</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-plugin-analytics-wsagent</artifactId>
+    <packaging>jar</packaging>
+    <name>Fabric8 IDE :: Plugins :: Segment Analytics Integration :: WsAgent part</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.segment.analytics.java</groupId>
+            <artifactId>analytics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-workspace-activity-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-json-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsActivityService.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsActivityService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsagent;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.eclipse.che.api.core.rest.Service;
+
+@Singleton
+@Path(AnalyticsActivityService.PATH)
+public class AnalyticsActivityService extends Service {
+  public static final String PATH = "/fabric8-che-analytics";
+
+  private final AnalyticsManager manager;
+
+  @Inject
+  public AnalyticsActivityService(AnalyticsManager manager) {
+    this.manager = manager;
+  }
+
+  @GET
+  @Path("activity")
+  public Response onActivity() {
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("stopped")
+  public Response stopped() {
+    manager.destroy();
+    return Response.ok().build();
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsActivityService.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsActivityService.java
@@ -17,6 +17,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import org.eclipse.che.api.core.rest.Service;
 
+/**
+ * This service endpoint receives from the Wsmaster workspaces-related events that are relevant for
+ * the AnalyticsManager (telemetry).
+ *
+ * <p>Such avents are activity notification or workspace stop event.
+ *
+ * <p>The endpoints only answers OK, because the corresponding API calls are already detected and
+ * leveraged by the {@link UrlToEventFilter} filter.
+ *
+ * @author David Festal
+ */
 @Singleton
 @Path(AnalyticsActivityService.PATH)
 public class AnalyticsActivityService extends Service {

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
@@ -20,9 +20,9 @@ public enum AnalyticsEvent {
   WORKSPACE_STOPPED("Stop Workspace in Che"),
   EDITOR_USED("Edit Workspace File In Che", 30, new String[] {PROGRAMMING_LANGUAGE});
 
-  private String name;
-  private int expectedDuration;
-  private String[] propertiesToCheck;
+  private final String name;
+  private final int expectedDuration;
+  private final String[] propertiesToCheck;
 
   AnalyticsEvent(String name, int expectedDurationSeconds, String[] propertiesToCheck) {
     this.name = name;
@@ -38,6 +38,7 @@ public enum AnalyticsEvent {
     this(name, -1, new String[0]);
   }
 
+  @Override
   public String toString() {
     return name;
   }

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
@@ -14,7 +14,7 @@ import static com.redhat.che.plugin.analytics.wsagent.EventProperties.*;
 
 public enum AnalyticsEvent {
   WORKSPACE_STARTED("Start Workspace in Che", 3),
-  WORKSPACE_OPENED("Refreshed Workspace in Che", 3),
+  WORKSPACE_OPENED("Refresh Workspace in Che", 3),
   WORKSPACE_USED("Use Workspace in Che"),
   WORKSPACE_INACTIVE("Keep Workspace Inactive in Che"),
   WORKSPACE_STOPPED("Stop Workspace in Che"),

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsagent;
+
+import static com.redhat.che.plugin.analytics.wsagent.EventProperties.*;
+
+public enum AnalyticsEvent {
+  WORKSPACE_STARTED("Start Workspace in Che", 3),
+  WORKSPACE_OPENED("Refreshed Workspace in Che", 3),
+  WORKSPACE_USED("Use Workspace in Che"),
+  WORKSPACE_INACTIVE("Keep Workspace Inactive in Che"),
+  WORKSPACE_STOPPED("Stop Workspace in Che"),
+  EDITOR_USED("Edit Workspace File In Che", 30, new String[] {PROGRAMMING_LANGUAGE});
+
+  private String name;
+  private int expectedDuration;
+  private String[] propertiesToCheck;
+
+  AnalyticsEvent(String name, int expectedDurationSeconds, String[] propertiesToCheck) {
+    this.name = name;
+    this.expectedDuration = expectedDurationSeconds;
+    this.propertiesToCheck = propertiesToCheck;
+  }
+
+  AnalyticsEvent(String name, int expectedDurationSeconds) {
+    this(name, expectedDurationSeconds, new String[0]);
+  }
+
+  AnalyticsEvent(String name) {
+    this(name, -1, new String[0]);
+  }
+
+  public String toString() {
+    return name;
+  }
+
+  public int getExpectedDurationSeconds() {
+    return expectedDuration;
+  }
+
+  public String[] getPropertiesToCheck() {
+    return propertiesToCheck;
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package com.redhat.che.plugin.analytics.wsagent;
+
+import static com.redhat.che.plugin.analytics.wsagent.AnalyticsEvent.*;
+import static com.redhat.che.plugin.analytics.wsagent.EventProperties.*;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.segment.analytics.Analytics;
+import com.segment.analytics.messages.TrackMessage;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.workspace.shared.dto.WorkspaceDto;
+import org.slf4j.Logger;
+
+/**
+ * Send event to Segment.com and regularly ping Woopra. For now the events are provided by the
+ * {@link UrlToEventFilter}.
+ *
+ * @author David Festal
+ */
+@Singleton
+public class AnalyticsManager {
+  private static final Logger LOG = getLogger(AnalyticsManager.class);
+
+  private final Analytics analytics;
+
+  private final long noActivityTimeout = 60000 * 3;
+  private final long pingTimeout = 30 * 1000;
+  private final String workspaceId;
+  private final String workspaceName;
+
+  private String segmentWriteKey;
+  private String woopraDomain;
+
+  private ScheduledExecutorService checkActivityExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(final Runnable r) {
+              return new Thread(
+                  new Runnable() {
+                    @Override
+                    public void run() {
+                      r.run();
+                    }
+                  },
+                  "Analytics Activity Checker");
+            }
+          });
+
+  private ScheduledExecutorService networkExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(final Runnable r) {
+              return new Thread(
+                  new Runnable() {
+                    @Override
+                    public void run() {
+                      r.run();
+                    }
+                  },
+                  "Analytics Network Request Submitter");
+            }
+          });
+
+  private LoadingCache<String, EventDispatcher> dispatchers;
+
+  private String workspaceStartingUserId = null;
+
+  @Inject
+  public AnalyticsManager(
+      @Named("env.CHE_WORKSPACE_ID") String workspaceId,
+      HttpJsonRequestFactory requestFactory,
+      @Named("che.api") String apiEndpoint) {
+    try {
+      String endpoint = apiEndpoint + "/fabric8-che-analytics/segment-write-key";
+      segmentWriteKey = requestFactory.fromUrl(endpoint).request().asString();
+
+      endpoint = apiEndpoint + "/fabric8-che-analytics/woopra-domain";
+      woopraDomain = requestFactory.fromUrl(endpoint).request().asString();
+    } catch (Exception e) {
+      throw new RuntimeException("Can't get Che analytics settings from wsmaster", e);
+    }
+
+    try {
+      String endpoint = apiEndpoint + "/workspace/" + workspaceId;
+      workspaceName =
+          requestFactory
+              .fromUrl(endpoint)
+              .request()
+              .asDto(WorkspaceDto.class)
+              .getConfig()
+              .getName();
+    } catch (Exception e) {
+      throw new RuntimeException("Can't get workspace name for Che analytics", e);
+    }
+
+    if (!segmentWriteKey.isEmpty() && woopraDomain.isEmpty()) {
+      throw new RuntimeException(
+          "The Woopra domain should be set to provide better visit tracking and duration calculation");
+    }
+
+    if (isEnabled()) {
+      analytics =
+          Analytics.builder(segmentWriteKey)
+              .networkExecutor(networkExecutor)
+              .flushQueueSize(1)
+              .build();
+    } else {
+      analytics = null;
+    }
+
+    this.workspaceId = workspaceId;
+
+    checkActivityExecutor.scheduleAtFixedRate(this::checkActivity, 20, 20, SECONDS);
+
+    dispatchers =
+        CacheBuilder.newBuilder()
+            .build(CacheLoader.<String, EventDispatcher>from(userId -> newEventDispatcher(userId)));
+  }
+
+  private EventDispatcher newEventDispatcher(String userId) {
+    return new EventDispatcher(userId, this);
+  }
+
+  public String getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public boolean isEnabled() {
+    return !segmentWriteKey.isEmpty();
+  }
+
+  public Analytics getAnalytics() {
+    return analytics;
+  }
+
+  private void checkActivity() {
+    LOG.debug("In checkActivity");
+    long inactiveLimit = System.currentTimeMillis() - noActivityTimeout;
+    dispatchers
+        .asMap()
+        .values()
+        .forEach(
+            dispatcher -> {
+              LOG.debug("Checking activity of dispatcher for user: {}", dispatcher.getUserId());
+              if (dispatcher.getLastActivityTime() < inactiveLimit) {
+                LOG.debug(
+                    "Sending 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
+                if (dispatcher.sendTrackEvent(
+                        WORKSPACE_INACTIVE,
+                        Collections.emptyMap(),
+                        dispatcher.getLastIp(),
+                        dispatcher.getLastUserAgent())
+                    != null) {
+                  LOG.debug("Sent 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
+                  return;
+                }
+                LOG.debug(
+                    "Skip sending 'WORKSPACE_INACTIVE' event for user: {} since it is the same event as the previous one",
+                    dispatcher.getUserId());
+              } else {
+                synchronized (dispatcher) {
+                  AnalyticsEvent lastEvent = dispatcher.getLastEvent();
+                  if (lastEvent == null) {
+                    return;
+                  }
+
+                  long expectedDuration = lastEvent.getExpectedDurationSeconds() * 1000;
+                  if (lastEvent == WORKSPACE_INACTIVE
+                      || (expectedDuration >= 0
+                          && System.currentTimeMillis()
+                              > expectedDuration + dispatcher.getLastEventTime())) {
+                    if (dispatcher.sendTrackEvent(
+                            WORKSPACE_USED,
+                            Collections.emptyMap(),
+                            dispatcher.getLastIp(),
+                            dispatcher.getLastUserAgent())
+                        != null) {
+                      return;
+                    }
+                  }
+                }
+              }
+
+              networkExecutor.submit(dispatcher::sendPingRequest);
+            });
+  }
+
+  public void onActivity(String userId) {
+    try {
+      dispatchers.get(userId).onActivity();
+    } catch (ExecutionException e) {
+      LOG.warn("", e);
+    }
+  }
+
+  public void onEvent(
+      String userId,
+      AnalyticsEvent event,
+      Map<String, Object> properties,
+      String ip,
+      String userAgent) {
+    if (event == WORKSPACE_STARTED) {
+      workspaceStartingUserId = userId;
+    }
+    try {
+      dispatchers.get(userId).sendTrackEvent(event, properties, ip, userAgent);
+    } catch (ExecutionException e) {
+      LOG.warn("", e);
+    }
+    ;
+  }
+
+  private class EventDispatcher {
+
+    private String userId;
+    private String cookie;
+
+    private AnalyticsEvent lastEvent = null;
+    private Map<String, Object> lastEventProperties = null;
+    private long lastActivityTime;
+    private long lastEventTime;
+    private String lastIp = null;
+    private String lastUserAgent = null;
+
+    private Map<String, Object> commonProperties;
+
+    EventDispatcher(String userId, AnalyticsManager manager) {
+      this.userId = userId;
+      this.commonProperties =
+          ImmutableMap.<String, Object>of(
+              WORKSPACE_ID, workspaceId,
+              WORKSPACE_NAME, workspaceName);
+      this.cookie =
+          Hashing.md5()
+              .hashString(workspaceId + userId + System.currentTimeMillis(), StandardCharsets.UTF_8)
+              .toString();
+      LOG.info(
+          "Analytics Woopra Cookie for user {} and workspace {} : {}", userId, workspaceId, cookie);
+    }
+
+    void onActivity() {
+      lastActivityTime = System.currentTimeMillis();
+    }
+
+    void sendPingRequest() {
+      try {
+        URI uri =
+            new URI(
+                "http://www.woopra.com/track/ping?host="
+                    + URLEncoder.encode(woopraDomain, "UTF-8")
+                    + "&cookie="
+                    + URLEncoder.encode(cookie, "UTF-8")
+                    + "&timeout="
+                    + pingTimeout);
+        LOG.debug("Sending a PING request to woopra for user '{}': {}", getUserId(), uri);
+        HttpURLConnection httpURLConnection = (HttpURLConnection) uri.toURL().openConnection();
+
+        String responseMessage;
+        try (BufferedReader br =
+                new BufferedReader(new InputStreamReader(httpURLConnection.getInputStream()));
+            StringWriter sw = new StringWriter()) {
+          String inputLine;
+
+          while ((inputLine = br.readLine()) != null) {
+            sw.write(inputLine);
+          }
+          responseMessage = sw.toString();
+        }
+        LOG.debug("Woopra PING response for user '{}': {}", userId, responseMessage);
+        if (responseMessage == null || !responseMessage.toString().contains("success: true")) {
+          LOG.warn("Cannot ping woopra: response message : {}", responseMessage);
+        }
+      } catch (Exception e) {
+        LOG.warn("Cannot ping woopra", e);
+      }
+    }
+
+    private boolean areEventsEqual(AnalyticsEvent event, Map<String, Object> properties) {
+      if (lastEvent == null || lastEvent != event) {
+        return false;
+      }
+
+      if (lastEventProperties == null) {
+        return false;
+      }
+
+      for (String propToCheck : event.getPropertiesToCheck()) {
+        Object lastValue = lastEventProperties.get(propToCheck);
+        Object newValue = properties.get(propToCheck);
+        if (lastValue != null && newValue != null && lastValue.equals(newValue)) {
+          continue;
+        }
+        if (lastValue == null && newValue == null) {
+          continue;
+        }
+        return false;
+      }
+
+      return true;
+    }
+
+    String sendTrackEvent(
+        AnalyticsEvent event, final Map<String, Object> properties, String ip, String userAgent) {
+      String eventId;
+      lastIp = ip;
+      lastUserAgent = userAgent;
+      final String theIp = ip != null ? ip : "0.0.0.0";
+      synchronized (this) {
+        lastEventTime = System.currentTimeMillis();
+        if (areEventsEqual(event, properties)) {
+          LOG.debug("Skipping event " + event.toString() + " since it is the same as the last one");
+          return null;
+        }
+
+        eventId = UUID.randomUUID().toString();
+        TrackMessage.Builder messageBuilder =
+            TrackMessage.builder(event.toString()).userId(userId).messageId(eventId);
+
+        ImmutableMap.Builder<String, Object> integrationBuilder =
+            ImmutableMap.<String, Object>builder().put("cookie", cookie);
+        if (event.getExpectedDurationSeconds() == 0) {
+          integrationBuilder.put("duration", 0);
+        }
+        messageBuilder.integrationOptions("Woopra", integrationBuilder.build());
+
+        ImmutableMap.Builder<String, Object> propertiesBuilder =
+            ImmutableMap.<String, Object>builder().putAll(commonProperties).putAll(properties);
+        messageBuilder.properties(propertiesBuilder.build());
+
+        ImmutableMap.Builder<String, Object> contextBuilder =
+            ImmutableMap.<String, Object>builder().put("ip", ip);
+        if (userAgent != null) {
+          contextBuilder.put("userAgent", userAgent);
+        }
+        if (event.getExpectedDurationSeconds() == 0) {
+          contextBuilder.put("duration", 0);
+        }
+        messageBuilder.context(contextBuilder.build());
+
+        LOG.debug(
+            "sending "
+                + event.toString()
+                + " (ip="
+                + theIp
+                + " - userAgent="
+                + userAgent
+                + ") with properties: "
+                + properties);
+        analytics.enqueue(messageBuilder);
+
+        lastEvent = event;
+        lastEventProperties = properties;
+      }
+      return eventId;
+    }
+
+    long getLastActivityTime() {
+      return lastActivityTime;
+    }
+
+    String getLastIp() {
+      return lastIp;
+    }
+
+    String getLastUserAgent() {
+      return lastUserAgent;
+    }
+
+    String getUserId() {
+      return userId;
+    }
+
+    AnalyticsEvent getLastEvent() {
+      return lastEvent;
+    }
+
+    long getLastEventTime() {
+      return lastEventTime;
+    }
+  }
+
+  @PreDestroy
+  void destroy() {
+    if (workspaceStartingUserId != null) {
+      EventDispatcher dispatcher;
+      try {
+        dispatcher = dispatchers.get(workspaceStartingUserId);
+        dispatcher.sendTrackEvent(
+            WORKSPACE_STOPPED,
+            Collections.emptyMap(),
+            dispatcher.getLastIp(),
+            dispatcher.getLastUserAgent());
+      } catch (ExecutionException e) {
+      }
+    }
+    checkActivityExecutor.shutdown();
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
@@ -32,6 +32,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -54,6 +55,9 @@ import org.slf4j.Logger;
 @Singleton
 public class AnalyticsManager {
   private static final Logger LOG = getLogger(AnalyticsManager.class);
+
+  private static final String pingRequestFormat =
+      "http://www.woopra.com/track/ping?host={0}&cookie={1}&timeout={2}";
 
   private final Analytics analytics;
 
@@ -282,12 +286,11 @@ public class AnalyticsManager {
       try {
         URI uri =
             new URI(
-                "http://www.woopra.com/track/ping?host="
-                    + URLEncoder.encode(woopraDomain, "UTF-8")
-                    + "&cookie="
-                    + URLEncoder.encode(cookie, "UTF-8")
-                    + "&timeout="
-                    + pingTimeout);
+                MessageFormat.format(
+                    pingRequestFormat,
+                    URLEncoder.encode(woopraDomain, "UTF-8"),
+                    URLEncoder.encode(cookie, "UTF-8"),
+                    Long.toString(pingTimeout)));
         LOG.debug("Sending a PING request to woopra for user '{}': {}", getUserId(), uri);
         HttpURLConnection httpURLConnection = (HttpURLConnection) uri.toURL().openConnection();
 

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
@@ -21,6 +21,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.segment.analytics.Analytics;
@@ -39,7 +40,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
@@ -71,35 +71,11 @@ public class AnalyticsManager {
 
   private ScheduledExecutorService checkActivityExecutor =
       Executors.newSingleThreadScheduledExecutor(
-          new ThreadFactory() {
-            @Override
-            public Thread newThread(final Runnable r) {
-              return new Thread(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      r.run();
-                    }
-                  },
-                  "Analytics Activity Checker");
-            }
-          });
+          new ThreadFactoryBuilder().setNameFormat("Analytics Activity Checker").build());
 
   private ScheduledExecutorService networkExecutor =
       Executors.newSingleThreadScheduledExecutor(
-          new ThreadFactory() {
-            @Override
-            public Thread newThread(final Runnable r) {
-              return new Thread(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      r.run();
-                    }
-                  },
-                  "Analytics Network Request Submitter");
-            }
-          });
+          new ThreadFactoryBuilder().setNameFormat("Analytics Network Request Submitter").build());
 
   private LoadingCache<String, EventDispatcher> dispatchers;
 

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsWsAgentModule.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsWsAgentModule.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsagent;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.workspace.activity.LastAccessTimeFilter;
+
+/**
+ * Module that allows pushing workspace events to the Segment Analytics tracking tool
+ *
+ * @author David festal
+ */
+@DynaModule
+public class AnalyticsWsAgentModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(LastAccessTimeFilter.class).to(OverridenLastAccessTimeFilter.class).asEagerSingleton();
+    bind(AnalyticsActivityService.class);
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsWsAgentServletModule.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsWsAgentServletModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsagent;
+
+import com.google.inject.servlet.ServletModule;
+import org.eclipse.che.inject.DynaModule;
+
+/**
+ * Module that allows pushing workspace events to the Segment and Woopra Analytics tracking tools
+ *
+ * @author David Festal
+ */
+@DynaModule
+public class AnalyticsWsAgentServletModule extends ServletModule {
+
+  @Override
+  protected void configureServlets() {
+    filter("/api/*").through(UrlToEventFilter.class);
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/EventProperties.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/EventProperties.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsagent;
+
+public interface EventProperties {
+  public static final String PROGRAMMING_LANGUAGE = "programming language";
+  public static final String WORKSPACE_ID = "workspace id";
+  public static final String WORKSPACE_NAME = "workspace name";
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/OverridenLastAccessTimeFilter.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/OverridenLastAccessTimeFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package com.redhat.che.plugin.analytics.wsagent;
+
+import java.io.IOException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.eclipse.che.workspace.activity.LastAccessTimeFilter;
+import org.eclipse.che.workspace.activity.WorkspaceActivityNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Overridden version of the {@link LastAccessTimeFilter} that ignores all accesses to the {@link
+ * AnalyticsActivityService}.
+ *
+ * <p>This important to avoid a REST messaging endless loop between the wsmaster and the wsagent
+ * related to activity notification forwarding.
+ *
+ * @author David Festal
+ */
+@Singleton
+public class OverridenLastAccessTimeFilter extends LastAccessTimeFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LastAccessTimeFilter.class);
+  private static final String PATH_TO_FILTER = "/api" + AnalyticsActivityService.PATH;
+
+  @Inject
+  public OverridenLastAccessTimeFilter(WorkspaceActivityNotifier wsActivityEventSender) {
+    super(wsActivityEventSender);
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    if (request instanceof HttpServletRequest) {
+      String path = ((HttpServletRequest) request).getServletPath();
+      if (path != null && path.startsWith(PATH_TO_FILTER)) {
+        LOG.debug(
+            "It's an activity notification from the wsmaster only for analytics: {}. Don't forward this back to the wsmaster !",
+            path);
+        chain.doFilter(request, response);
+        return;
+      }
+    }
+
+    super.doFilter(request, response, chain);
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/OverridenLastAccessTimeFilter.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/OverridenLastAccessTimeFilter.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * Overridden version of the {@link LastAccessTimeFilter} that ignores all accesses to the {@link
  * AnalyticsActivityService}.
  *
- * <p>This important to avoid a REST messaging endless loop between the wsmaster and the wsagent
+ * <p>This is important to avoid a REST messaging endless loop between the wsmaster and the wsagent
  * related to activity notification forwarding.
  *
  * @author David Festal

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/UrlToEventFilter.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/UrlToEventFilter.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package com.redhat.che.plugin.analytics.wsagent;
+
+import static com.redhat.che.plugin.analytics.wsagent.AnalyticsEvent.*;
+import static com.redhat.che.plugin.analytics.wsagent.EventProperties.*;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Singleton;
+import java.io.IOException;
+import java.util.Collections;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.eclipse.che.api.languageserver.registry.LanguageRecognizer;
+import org.eclipse.che.api.languageserver.shared.model.LanguageDescription;
+import org.eclipse.che.commons.subject.Subject;
+import org.slf4j.Logger;
+
+/**
+ * Filter the API accesses and convert some of them into meaningful events to be consumed by the
+ * {@link AnalyticsManager}.
+ *
+ * <p>Also detects the workspace activity and notifies the {@link AnalyticsManager} about it.
+ *
+ * @author David Festal
+ */
+@Singleton
+public class UrlToEventFilter implements Filter {
+  private static final Logger LOG = getLogger(UrlToEventFilter.class);
+
+  private boolean startWorkspaceEventSent = false;
+  private final AnalyticsManager manager;
+  private final LanguageRecognizer languageRecognizer;
+
+  @Inject
+  public UrlToEventFilter(AnalyticsManager manager, LanguageRecognizer languageRecognizer) {
+    this.manager = manager;
+    this.languageRecognizer = languageRecognizer;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    chain.doFilter(request, response);
+    try {
+      if (!manager.isEnabled()) {
+        return;
+      }
+      if (!(request instanceof HttpServletRequest)) {
+        return;
+      }
+
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+      String path = httpRequest.getServletPath();
+
+      if ("/api/liveness".contentEquals(path)) {
+        return;
+      }
+
+      String ip = httpRequest.getHeader("X-Forwarded-For");
+      if (ip == null) {
+        ip = httpRequest.getRemoteAddr();
+      }
+
+      String userAgent = httpRequest.getHeader("User-Agent");
+
+      String method = httpRequest.getMethod();
+
+      final HttpSession session = httpRequest.getSession();
+      Subject subject = (Subject) session.getAttribute("principal");
+      if (subject == null) {
+        LOG.warn("No Subject to find out a user for analytics");
+        return;
+      }
+      String userId = subject.getUserId();
+      if (userId == null) {
+        LOG.warn("No userId to find out a user for analytics");
+        return;
+      }
+
+      synchronized (this) {
+        if ("GET".equals(method) && path.startsWith("/api/project-type")) {
+          if (!startWorkspaceEventSent) {
+            startWorkspaceEventSent = true;
+            manager.onEvent(userId, WORKSPACE_STARTED, Collections.emptyMap(), ip, userAgent);
+          } else {
+            manager.onEvent(userId, WORKSPACE_OPENED, Collections.emptyMap(), ip, userAgent);
+          }
+          return;
+        }
+
+        if (!startWorkspaceEventSent) {
+          return;
+        }
+      }
+
+      if ("PUT".equals(method) && path.startsWith("/api/project/file")) {
+        String language = guessLanguage(path);
+        manager.onEvent(
+            userId,
+            EDITOR_USED,
+            ImmutableMap.<String, Object>builder().put(PROGRAMMING_LANGUAGE, language).build(),
+            ip,
+            userAgent);
+      }
+
+      manager.onActivity(userId);
+    } catch (Exception e) {
+      LOG.error("", e);
+    }
+  }
+
+  private String guessLanguage(String path) {
+    String language;
+    if (path.endsWith(".xml")) {
+      return "xml";
+    }
+    if (path.endsWith(".js")) {
+      return "javascript";
+    }
+    if (path.endsWith(".jsp")) {
+      return "jsp";
+    }
+    LanguageDescription languageDesc = languageRecognizer.recognizeByPath(path.substring(17));
+    if (languageDesc == LanguageRecognizer.UNIDENTIFIED) {
+      String extension = "";
+      String fileName = path;
+      int lastSlash = path.lastIndexOf('/');
+      if (lastSlash >= 0) {
+        fileName = path.substring(lastSlash + 1);
+      }
+      int lastPoint = fileName.lastIndexOf('.');
+      if (lastPoint > 0) {
+        extension = fileName.substring(lastPoint + 1);
+      }
+      if (extension.isEmpty()) {
+        language = "unknown";
+      } else {
+        language = "unknown : ." + extension;
+      }
+    } else {
+      language = languageDesc.getLanguageId();
+    }
+    return language;
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
@@ -24,12 +24,16 @@
     <name>Fabric8 IDE :: Plugins :: Segment Analytics Integration :: WsMaster part</name>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
+            <artifactId>guice-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -41,7 +45,19 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -56,12 +72,26 @@
             <artifactId>che-multiuser-machine-authentication</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication-shared</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -80,20 +110,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
@@ -14,7 +14,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>fabric8-ide-plugins-parent</artifactId>
+        <artifactId>che-plugin-analytics</artifactId>
         <groupId>com.redhat.che</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2016-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>fabric8-ide-plugins-parent</artifactId>
+        <groupId>com.redhat.che</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-plugin-analytics-wsmaster</artifactId>
+    <packaging>jar</packaging>
+    <name>Fabric8 IDE :: Plugins :: Segment Analytics Integration :: WsMaster part</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsSettingsService.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsSettingsService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsmaster;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.eclipse.che.api.core.rest.Service;
+import org.eclipse.che.commons.annotation.Nullable;
+
+@Path("fabric8-che-analytics")
+public class AnalyticsSettingsService extends Service {
+
+  String segmentWriteKey;
+  String woopraDomain;
+
+  @Inject
+  public AnalyticsSettingsService(
+      @Nullable @Named("che.fabric8.analytics.segment_write_key") String segmentWriteKey,
+      @Nullable @Named("che.fabric8.analytics.woopra_domain") String woopraDomain) {
+    this.segmentWriteKey = segmentWriteKey;
+    this.woopraDomain = woopraDomain;
+  }
+
+  @GET
+  @Path("segment-write-key")
+  public String segmentWriteKey() {
+    return segmentWriteKey == null ? "" : segmentWriteKey;
+  }
+
+  @GET
+  @Path("woopra-domain")
+  public String woopraDomain() {
+    return woopraDomain == null ? "" : woopraDomain;
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsWsMasterModule.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsWsMasterModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsmaster;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.inject.DynaModule;
+
+/**
+ * Module that allows pushing workspace events to the Segment Analytics tracking tool
+ *
+ * @author David festal
+ */
+@DynaModule
+public class AnalyticsWsMasterModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(AnalyticsSettingsService.class);
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsWsMasterServletModule.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/AnalyticsWsMasterServletModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.plugin.analytics.wsmaster;
+
+import com.google.inject.servlet.ServletModule;
+import org.eclipse.che.inject.DynaModule;
+
+/**
+ * Module that allows pushing workspace events to the Segment Analytics tracking tool
+ *
+ * @author David festal
+ */
+@DynaModule
+public class AnalyticsWsMasterServletModule extends ServletModule {
+
+  @Override
+  protected void configureServlets() {
+    filter("/activity/*").through(ForwardActivityFilter.class);
+  }
+}

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/ForwardActivityFilter.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/ForwardActivityFilter.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package com.redhat.che.plugin.analytics.wsmaster;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_ID_CLAIM;
+
+import com.google.inject.Singleton;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriBuilder;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
+import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
+import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter that forwards, to the WSAgent, workspaces-related events that are relevant for the WsAgent
+ * AnalyticsManager (telemetry).
+ *
+ * @author David Festal
+ */
+@Singleton
+public class ForwardActivityFilter implements Filter, EventSubscriber<WorkspaceStatusEvent> {
+  private static final Logger LOG = LoggerFactory.getLogger(ForwardActivityFilter.class);
+
+  private final WorkspaceManager workspaceManager;
+  private final MachineTokenProvider machineTokenProvider;
+  private final RequestTokenExtractor tokenExtractor;
+  private final SignatureKeyManager keyManager;
+
+  @Inject
+  public ForwardActivityFilter(
+      WorkspaceManager workspaceManager,
+      MachineTokenProvider machineTokenProvider,
+      RequestTokenExtractor tokenExtractor,
+      SignatureKeyManager keyManager) {
+    this.workspaceManager = workspaceManager;
+    this.machineTokenProvider = machineTokenProvider;
+    this.tokenExtractor = tokenExtractor;
+    this.keyManager = keyManager;
+  }
+
+  @Inject
+  void subscribe(EventService eventService) {
+    eventService.subscribe(this);
+  }
+
+  @Override
+  public void onEvent(WorkspaceStatusEvent event) {
+    String workspaceId = event.getWorkspaceId();
+    if (WorkspaceStatus.STOPPING.equals(event.getStatus())) {
+      try {
+        final WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
+        String userId = workspace.getRuntime().getOwner();
+        callWorkspaceAnalyticsEndpoint(
+            userId, workspaceId, "/fabric8-che-analytics/stopped", "notify stop", workspace);
+      } catch (NotFoundException | ServerException e) {
+        LOG.warn("", e);
+        return;
+      }
+    }
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  private void forwardActivity(ServletRequest request) {
+    if (!(request instanceof HttpServletRequest)) {
+      return;
+    }
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+    try {
+      String[] pathParts = httpRequest.getServletPath().split("/");
+      if (pathParts.length <= 1) {
+        return;
+      }
+
+      String userId = extractUserId(httpRequest);
+
+      String workspaceId = pathParts[pathParts.length - 1];
+      if (workspaceId == null) {
+        return;
+      }
+
+      try {
+        final WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
+        if (workspace.getStatus() == RUNNING) {
+          callWorkspaceAnalyticsEndpoint(
+              userId,
+              workspaceId,
+              "/fabric8-che-analytics/activity",
+              "forward activity",
+              workspace);
+        } else {
+          LOG.debug(
+              "In Forward Activity for path: {} - workspace {} is NOT RUNNING",
+              httpRequest.getServletPath(),
+              workspaceId);
+        }
+      } catch (NotFoundException e) {
+        LOG.warn(
+            "In Forward Activity for path: {} - workspace {} is NOT FOUND",
+            httpRequest.getServletPath(),
+            workspaceId);
+      }
+    } catch (Exception e) {
+      LOG.error("Cannot forward activity to the wsagent for analytics", e);
+    }
+  }
+
+  private void callWorkspaceAnalyticsEndpoint(
+      String userId,
+      String workspaceId,
+      String targetEndpoint,
+      String action,
+      final WorkspaceImpl workspace) {
+    workspace
+        .getRuntime()
+        .getMachines()
+        .values()
+        .stream()
+        .flatMap(machine -> machine.getServers().entrySet().stream())
+        .filter(entry -> "wsagent/http".equals(entry.getKey()))
+        .map(entry -> entry.getValue())
+        .forEach(
+            server -> {
+              try {
+                URI uri = UriBuilder.fromUri(server.getUrl()).path(targetEndpoint).build();
+
+                int port;
+                if (uri.getPort() == -1) {
+                  if ("http".equals(uri.getScheme())) {
+                    port = 80;
+                  } else {
+                    port = 443;
+                  }
+                } else {
+                  port = uri.getPort();
+                }
+
+                LOG.debug("{} on workspace {} to {} for user {}", action, workspaceId, uri, userId);
+
+                HttpURLConnection httpURLConnection =
+                    (HttpURLConnection) uri.toURL().openConnection();
+                httpURLConnection.setRequestProperty(
+                    HttpHeaders.AUTHORIZATION, machineTokenProvider.getToken(userId, workspaceId));
+                int responseCode = httpURLConnection.getResponseCode();
+                if (responseCode != 200) {
+                  LOG.error(
+                      "Cannot {} to the wsagent for analytics: response code = {}",
+                      action,
+                      responseCode);
+                }
+              } catch (Exception e) {
+                LOG.error("Cannot " + action + " to the wsagent for analytics", e);
+              }
+            });
+  }
+
+  private String extractUserId(HttpServletRequest httpRequest) {
+    // First search in the session fro activity notification coming from the client
+
+    final HttpSession session = httpRequest.getSession();
+
+    Subject subject = (Subject) session.getAttribute("che_subject");
+    if (subject != null) {
+      String userId = subject.getUserId();
+      if (userId != null) {
+        return userId;
+      }
+    }
+
+    // Then search in the machine token for activity notification coming from the agents
+
+    final String token = tokenExtractor.getToken(httpRequest);
+
+    if (isNullOrEmpty(token)) {
+      return null;
+    }
+
+    // check token signature and verify is this token machine or not
+    try {
+      final Jws<Claims> jwt =
+          Jwts.parser().setSigningKey(keyManager.getKeyPair().getPublic()).parseClaimsJws(token);
+      final Claims claims = jwt.getBody();
+
+      if (MACHINE_TOKEN_KIND.equals(jwt.getHeader().get("kind"))) {
+        return claims.get(USER_ID_CLAIM, String.class);
+      }
+    } catch (UnsupportedJwtException
+        | MalformedJwtException
+        | SignatureException
+        | ExpiredJwtException ex) {
+      LOG.warn("Could not get a user Id from a machine token", ex);
+    }
+    return null;
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    chain.doFilter(request, response);
+    forwardActivity(request);
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/plugins/che-plugin-analytics/pom.xml
+++ b/plugins/che-plugin-analytics/pom.xml
@@ -14,19 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>fabric8-ide-parent</artifactId>
+        <artifactId>fabric8-ide-plugins-parent</artifactId>
         <groupId>com.redhat.che</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <artifactId>fabric8-ide-plugins-parent</artifactId>
+    <artifactId>che-plugin-analytics</artifactId>
     <packaging>pom</packaging>
-    <name>Fabric8 IDE :: Plugins</name>
+    <name>Fabric8 IDE :: Plugins :: Analytics</name>
     <modules>
-        <module>ls-bayesian-agent</module>
-        <module>che-plugin-bayesian-lang-server</module>
-        <module>plugin-product-info</module>
-        <module>fabric8-multi-tenant-manager</module>
-        <module>che-plugin-analytics</module>
+        <module>che-plugin-analytics-wsmaster</module>
+        <module>che-plugin-analytics-wsagent</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,25 @@
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>
+        <segment.analytics.client.java.version>2.1.1</segment.analytics.client.java.version>
         <sentry.version>1.7.2</sentry.version>
         <unleash.client.java.version>3.0.0</unleash.client.java.version>
         <withoutDashboard>false</withoutDashboard>
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.redhat.che</groupId>
+                <artifactId>che-plugin-analytics-wsagent</artifactId>
+                <version>${redhat.che.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>com.redhat.che</groupId>
+                <artifactId>che-plugin-analytics-wsmaster</artifactId>
+                <version>${redhat.che.version}</version>
+                <type>jar</type>
+            </dependency>
             <dependency>
                 <groupId>com.redhat.che</groupId>
                 <artifactId>che-plugin-bayesian-lang-server</artifactId>
@@ -112,6 +125,11 @@
                 <type>jar</type>
             </dependency>
             <dependency>
+                <groupId>com.segment.analytics.java</groupId>
+                <artifactId>analytics</artifactId>
+                <version>${segment.analytics.client.java.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry</artifactId>
                 <version>${sentry.version}</version>
@@ -137,6 +155,12 @@
                 <artifactId>fabric8-ide-gwt-app</artifactId>
                 <version>${rh.che.plugins.version}</version>
                 <type>gwt-app</type>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.multiuser</groupId>
+                <artifactId>che-multiuser-machine-authentication</artifactId>
+                <version>${che.version}</version>
+                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
                 <version>${segment.analytics.client.java.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.segment.analytics.java</groupId>
+                <artifactId>analytics-core</artifactId>
+                <version>${segment.analytics.client.java.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry</artifactId>
                 <version>${sentry.version}</version>


### PR DESCRIPTION
### What does this PR do?

It adds telemetry in the Che workspaces feeding the Segment and Woopra tools with events and precise durations.

Events types are:
- workspace start
- workspace use (any activity in the IDE or agents apart from editing a file)
- edition of file (when a file is saved): contains a property with the programming language
- workspace inactivity : when the user hasn't been using the workspace for more than 3 minutes but it was still not idled
- workspace stop: when the workspace is stopped by the Che server 

### What issues does this PR fix or reference?

https://github.com/redhat-developer/rh-che/issues/630

### How have you tested this PR?

Yes, on Dev cluster

The results of my last session pushed into the `test.openshift.io` can be seen [here](https://www.woopra.com/live/project/test.openshift.io/people/all/id/U2yqnIj1mSp7)