### PR TITLE
rh-che #532 Using 'identity_id' as query parameter in oso proxy url

### DIFF
--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/multicluster/MultiClusterOpenShiftProxy.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/multicluster/MultiClusterOpenShiftProxy.java
@@ -33,4 +33,8 @@ public class MultiClusterOpenShiftProxy {
   public String getUrl() {
     return this.url;
   }
+
+  public String getUrlWithIdentityIdQueryParameter(String identityId) {
+    return this.url + "?identity_id=" + identityId;
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Using 'identity_id' as query parameter in oso proxy url in order to support che sa oath token processing

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/532

### How have you tested this PR?
Some notes about testing oso-proxy with support of `identity_id` query parameter:
1.  Looks like oso proxy understand `identity_id` only via vanilla `curl`. `oc` commands does not seem to work with oso-proxy e.g. 

`oc login oso-proxy-url?identity_id=<identity_id> --token=<che_sa_token> -n che-namespace`

results in

> Error in configuration: context was not found for specified context

Not sure if this is crucial for che namespace lockdown, since all interactions with oso-proxy happens via kubernetes-client [1]

2. while testing oso-proxy with k8s client I figured out that query parameters are not correctly processed:

```
          ConfigBuilder configBuilder =
                  new ConfigBuilder()
                      .withMasterUrl("https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com?identity_id=" + identityId)
                      .withNamespace("namespace-che")
                      .withTrustCerts(true)
                      .withOauthToken(cheServiceAccountToken);
          
          
          OpenShiftClient openShiftClient = new DefaultOpenShiftClient(configBuilder.build());
          List<Pod> items = openShiftClient.pods().list().getItems();
          for (Pod pod : items) {
              System.out.println(pod.getMetadata().getName());
          } 
```

This sample fails with the following error message:
```
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com/?identity_id=<identity_id>/api/v1/namespaces/namespace-che/pods. Message: Unauthorized! Token may have expired! Please log-in again..
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:470)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:407)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:379)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:343)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:327)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.list(BaseOperation.java:605)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.list(BaseOperation.java:70)
	at com.redhat.che.multitenant.Test.main(Test.java:70)

```
Basically, k8s client does not seem to honour query parameters and simply concatenates `/api/` segments to it so that `/?identity_id=<identity_id>/` becomes part of url. It was discussed  with @aslakknutsen and @nurali-techie to temporary workaround this on oso-proxy side by parsing url segment with the query parameter and removing it once `identity_id` is obtained. The real solution would be using `requestConfig.setImpersonateUsername()` for setting `identity_id` which should pass it via `Impersonate-User` header. Unfortunately, this api is not supported by the current version of k8s client we are using `3.1.0` and update to the latest version `3.1.12` is required in upstream che project. 

[1] https://github.com/fabric8io/kubernetes-client