### PR TITLE
Switch to the `6.6.2` bugfix release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>6.6.1</version>
+        <version>6.6.2</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?

It updates `rh-che` to the `6.6.2` upstream bugfix release to reintegrate important fixes that were only in `6.7.0-SNAPSHOT`

### What issues does this PR fix or reference?

no issue in fact

### How have you tested this PR?

Tested on dev-cluster before creating the PR