### PR TITLE
Changing default pull policy to `IfNotPresent` for rh-che minishift addon

### DIFF
--- a/openshift/minishift-addons/rhche/templates/rh-che.app.yaml
+++ b/openshift/minishift-addons/rhche/templates/rh-che.app.yaml
@@ -314,8 +314,8 @@ parameters:
   value: 'Recreate'
 - name: PULL_POLICY
   displayName: Che server image pull policy
-  description: Always pull by default. Can be IfNotPresent
-  value: 'Always'
+  description: Pull the image only if not present in the local registry by default. Can be 'Always' and 'Never'
+  value: 'IfNotPresent'
 - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
   displayName: User Service Endpoint
   description: URL of the user services API endpoint


### PR DESCRIPTION

Currently if I want to use custom image with `rhche` addon I have to do smth. like that:

```
minishift addons apply \
    --addon-env RH_CHE_DOCKER_IMAGE=ibuziuk/che-server \
    --addon-env RH_CHE_VERSION=rhche1 \
    --addon-env PULL_POLICY=Never \
    rhche
```

It would be great to change default pull policy from "Always" to "IfNotPresent" by default imo
