### PR TITLE
Updated oc tool in prcheck ci script to 3.9.0

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -20,7 +20,7 @@ set +o nounset
 export RH_CHE_AUTOMATION_SERVER_DEPLOYMENT_URL=https://rhche-che6-automated.dev.rdu2c.fabric8.io/
 export BASEDIR=$(pwd)
 export DEV_CLUSTER_URL=https://dev.rdu2c.fabric8.io:8443/
-export OC_VERSION=3.7.48
+export OC_VERSION=3.9.33
 export TARGET=${TARGET:-"rhel"}
 export PR_CHECK_BUILD=${PR_CHECK_BUILD:-"true"}
 


### PR DESCRIPTION
### What does this PR do?
Updates OC version to 3.9.0 to be compatible with openshift server deployed on dev.rdu2c. This will hopefully fix https://github.com/redhat-developer/che-functional-tests/issues/310

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/310
