### PR TITLE
rhche #726: Changing deployment strategy from 'Recreate' to 'Rolling'

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -37,9 +37,9 @@ objects:
     selector:
       app: rhche
     strategy:
-      recreateParams:
+      rollingParams:
         timeoutSeconds: 10000
-      type: Recreate
+      type: Rolling
     template:
       metadata:
         labels:


### PR DESCRIPTION
### What does this PR do?
Changing rhche deployment strategy from 'Recreate' to 'Rolling'

### What issues does this PR fix or reference?
Should potentially improve the situation with https://github.com/redhat-developer/rh-che/issues/726

### How have you tested this PR?
yes, on dev cluster with the help of the whole team. Workspaces were created and started and rollout of the deployment was performed many times:

![image](https://user-images.githubusercontent.com/1461122/42948259-655ca5f4-8b6f-11e8-844a-af72c13a14fe.png)

Workspaces were still running during multiple updates. No issues were spotted a part from known [1] [2]

[1] https://github.com/eclipse/che/issues/9740 
[2] https://github.com/eclipse/che-docs/blob/master/src/main/pages/setup-openshift/admin-guide.md#known-issues