### PR TITLE
Removed code starting che-starter

### DIFF
--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -42,16 +42,6 @@
                 <!-- <version>${che.version}</version> -->
                 <version>6.8.0</version>
             </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-api-maven-embedded</artifactId>
-                <version>3.1.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-impl-maven-embedded</artifactId>
-                <version>3.1.3</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -109,25 +99,12 @@
             <artifactId>che-selenium-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api-maven-embedded</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven-embedded</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
@@ -56,7 +56,7 @@ public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
   @Override
   public TestWorkspace createWorkspace(
       TestUser owner, int memoryGB, String template, boolean startAfterCreation) {
-    this.cheStarterWrapper.start();
+    this.cheStarterWrapper.checkIsRunning();
     return new RhCheTestWorkspaceImpl(
         owner,
         testWorkspaceServiceClient instanceof RhCheTestWorkspaceServiceClient

--- a/functional-tests/src/test/resources/conf/selenium.properties
+++ b/functional-tests/src/test/resources/conf/selenium.properties
@@ -15,6 +15,7 @@ tests.htmldumps_dir=target/htmldumps
 tests.workspacelogs_dir=target/workspace-logs
 tests.webdriverlogs_dir=target/webdriver-logs
 tests.download_dir=target/test_downloads
+tests.tmp_dir=/tmp
 
 # Che workspace parameters
 che.workspace_agent_dev_inactive_stop_timeout_ms=300000


### PR DESCRIPTION
### What does this PR do?
Removed code, which was starting che-starter, from codebase. Now the tests expect the che-starter to be started before executing tests (most possibly by running che-starter docker image - not part of this PR).

This allows us to get rid of few, now unnecessary, dependencies.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/305

### How have you tested this PR?
build locally fine, Run dummy test case with che-starter started (passed) & Run dummy test case with che-starter stopped (failed as expected)