### PR TITLE
Increase the `ha-proxy` timeout on the workspace agent route

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
@@ -24,3 +24,6 @@ che.fabric8.analytics.woopra_domain=NULL
 
 # Option to run rh-che in standalone mode, typically on Minishift (without accessing sibling fabric8 services) 
 che.fabric8.standalone=false
+
+# Option to change the HA router timeout for the route of the wsagent API endpoint 
+che.fabric8.wsagent_routing_timeout=10m


### PR DESCRIPTION
### What does this PR do?

The PR allows setting the ha-proxy timeout for the ws-agent route to a longer value (10 minutes by default) for workspace PODs.
This is necessary to support long synchronous calls to the ws-agent API, such as a Git clone of a large repository.

### What issues does this PR fix or reference?

No precise issue on this, but the problem was encountered in the context of issue https://github.com/redhat-developer/rh-che/issues/729

### How have you tested this PR?

Yes, on Dev-cluster, and this allowed the vertx eclipse factory to work again.