### PR TITLE
Adapt PR-check to run with pre-built docker image

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -27,7 +27,11 @@ export PR_CHECK_BUILD=${PR_CHECK_BUILD:-"true"}
 function BuildTagAndPushDocker() {
   echo "Docker status:"
   docker images
-  .ci/cico_build.sh
+#  .ci/cico_build.sh
+  ABSOLUTE_PATH=$(cd $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../ && pwd)
+  docker run --privileged=true -u root -v ${ABSOLUTE_PATH}/:/data/rhche quay.io/tdancs/rh-che-pr-check-dep:latest mvn clean install -f /data/rhche/
+  source ./config
+  .ci/cico_do_docker_build_tag_push.sh
   echo "After build:"
   docker images
 }
@@ -91,30 +95,19 @@ yum install python-pip --assumeyes
 # Test and show version
 pip -V
 
-# Getting dependencies ready
+# Getting dependencies read
+
 yum install --assumeyes \
             docker \
-            git \
-            patch \
-            pcp \
-            bzip2 \
-            golang \
-            make \
             jq \
-            java-1.8.0-openjdk \
-            java-1.8.0-openjdk-devel \
-            centos-release-scl
+            git
 
-yum install --assumeyes \
-            rh-maven33 \
-            rh-nodejs4
-
-systemctl start docker
 pip install yq
 
 set +x
 # Build and push image to docker registry
 source ./config
+systemctl start docker
 BuildTagAndPushDocker
 
 # Deploy rh-che image

--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -27,11 +27,12 @@ export PR_CHECK_BUILD=${PR_CHECK_BUILD:-"true"}
 function BuildTagAndPushDocker() {
   echo "Docker status:"
   docker images
-  ABSOLUTE_PATH=$(cd $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../ && pwd)
-  docker run --privileged=true -u root \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v ${ABSOLUTE_PATH}/:/data/rhche/ \
-  quay.io/openshiftio/rhchestage-rh-che-automation-dep:latest scl enable rh-maven33 rh-nodejs4 "mvn -B -f /data/rhche/ clean install"
+  .ci/cico_build.sh
+#  ABSOLUTE_PATH=$(cd $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../ && pwd)
+#  docker run --privileged=true -u root \
+#  -v /var/run/docker.sock:/var/run/docker.sock \
+#  -v ${ABSOLUTE_PATH}/:/data/rhche/ \
+#  quay.io/openshiftio/rhchestage-rh-che-automation-dep:latest scl enable rh-maven33 rh-nodejs4 "mvn -B -f /data/rhche/ clean install"
   .ci/cico_do_docker_build_tag_push.sh
   echo "After build:"
   docker images


### PR DESCRIPTION
### What does this PR do?
Updating how our PR-checks workflow works, rewriting the cico script to use the dependency docker image instead of on-premise dependency downloads.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/312

### How have you tested this PR?
deployments on dev.rdu2c.fabric8.io
testing shows reduction of 10 minutes from the PR-Check runs.