### PR TITLE
End to end user registration flow with telemetry support.

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -125,8 +125,7 @@ if ./dev-scripts/deploy_custom_rh-che.sh -u "${RH_CHE_AUTOMATION_RDU2C_USERNAME}
                                          -t nightly-"${RH_TAG_DIST_SUFFIX}" \
                                          -e che6-automated \
                                          -s \
-                                         -U \
-                                         -z;
+                                         -U;
 then
   echo "Che successfully deployed."
 else

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/OIDCKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/OIDCKeycloak.js
@@ -1,0 +1,1409 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+/*
+ * This is a modified version of the Keycloak Javascript Adapter whose 
+ * original sources can be found there: 
+ * https://github.com/keycloak/keycloak/blob/master/adapters/oidc/js/src/main/resources/keycloak.js
+ * 
+ * Modifications allow using the Keycloak Javascript Adapter library with alternate OIDC-compliant providers,
+ * provided that they produce access tokens as JWT tokens with `iat` and `exp` claims.
+ */
+
+(function( window, undefined ) {
+
+    var Keycloak = function (config) {
+        if (!(this instanceof Keycloak)) {
+            return new Keycloak(config);
+        }
+
+        var kc = this;
+        var adapter;
+        var refreshQueue = [];
+        var callbackStorage;
+
+        var loginIframe = {
+            enable: true,
+            callbackList: [],
+            interval: 5
+        };
+
+        var useNonce = true;
+        
+        kc.init = function (initOptions) {
+            kc.authenticated = false;
+
+            callbackStorage = createCallbackStorage();
+
+            if (initOptions && initOptions.adapter === 'cordova') {
+                adapter = loadAdapter('cordova');
+            } else if (initOptions && initOptions.adapter === 'default') {
+                adapter = loadAdapter();
+            } else {
+                if (window.Cordova) {
+                    adapter = loadAdapter('cordova');
+                } else {
+                    adapter = loadAdapter();
+                }
+            }
+
+            if (initOptions) {
+                if (typeof initOptions.useNonce !== 'undefined') {
+                    useNonce = initOptions.useNonce;
+                }
+
+                if (typeof initOptions.checkLoginIframe !== 'undefined') {
+                    loginIframe.enable = initOptions.checkLoginIframe;
+                }
+
+                if (initOptions.checkLoginIframeInterval) {
+                    loginIframe.interval = initOptions.checkLoginIframeInterval;
+                }
+
+                if (initOptions.onLoad === 'login-required') {
+                    kc.loginRequired = true;
+                }
+
+                if (initOptions.responseMode) {
+                    if (initOptions.responseMode === 'query' || initOptions.responseMode === 'fragment') {
+                        kc.responseMode = initOptions.responseMode;
+                    } else {
+                        throw 'Invalid value for responseMode';
+                    }
+                }
+
+                if (initOptions.flow) {
+                    switch (initOptions.flow) {
+                        case 'standard':
+                            kc.responseType = 'code';
+                            break;
+                        case 'implicit':
+                            kc.responseType = 'id_token token';
+                            break;
+                        case 'hybrid':
+                            kc.responseType = 'code id_token token';
+                            break;
+                        default:
+                            throw 'Invalid value for flow';
+                    }
+                    kc.flow = initOptions.flow;
+                }
+
+                if (initOptions.timeSkew != null) {
+                    kc.timeSkew = initOptions.timeSkew;
+                }
+            }
+
+            if (!kc.responseMode) {
+                kc.responseMode = 'fragment';
+            }
+            if (!kc.responseType) {
+                kc.responseType = 'code';
+                kc.flow = 'standard';
+            }
+
+            var promise = createPromise();
+
+            var initPromise = createPromise();
+            initPromise.promise.success(function() {
+                kc.onReady && kc.onReady(kc.authenticated);
+                promise.setSuccess(kc.authenticated);
+            }).error(function(errorData) {
+                promise.setError(errorData);
+            });
+
+            var configPromise = loadConfig(config);
+
+            function onLoad() {
+                var doLogin = function(prompt) {
+                    if (!prompt) {
+                        options.prompt = 'none';
+                    }
+                    kc.login(options).success(function () {
+                        initPromise.setSuccess();
+                    }).error(function (errorData) {
+                        initPromise.setError(errorData);
+                    });
+                }
+
+                var options = {};
+                switch (initOptions.onLoad) {
+                    case 'check-sso':
+                        if (loginIframe.enable) {
+                            setupCheckLoginIframe().success(function() {
+                                checkLoginIframe().success(function () {
+                                    doLogin(false);
+                                }).error(function () {
+                                    initPromise.setSuccess();
+                                });
+                            });
+                        } else {
+                            doLogin(false);
+                        }
+                        break;
+                    case 'login-required':
+                        doLogin(true);
+                        break;
+                    default:
+                        throw 'Invalid value for onLoad';
+                }
+            }
+
+            function processInit() {
+                var callback = parseCallback(window.location.href);
+
+                if (callback) {
+                    setupCheckLoginIframe();
+                    window.history.replaceState({}, null, callback.newUrl);
+                    processCallback(callback, initPromise);
+                    return;
+                } else if (initOptions) {
+                    if (initOptions.token && initOptions.refreshToken) {
+                        setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
+
+                        if (loginIframe.enable) {
+                            setupCheckLoginIframe().success(function() {
+                                checkLoginIframe().success(function () {
+                                    kc.onAuthSuccess && kc.onAuthSuccess();
+                                    initPromise.setSuccess();
+                                }).error(function () {
+                                    setToken(null, null, null);
+                                    initPromise.setSuccess();
+                                });
+                            });
+                        } else {
+                            kc.updateToken(-1).success(function() {
+                                kc.onAuthSuccess && kc.onAuthSuccess();
+                                initPromise.setSuccess();
+                            }).error(function() {
+                                kc.onAuthError && kc.onAuthError();
+                                if (initOptions.onLoad) {
+                                    onLoad();
+                                } else {
+                                    initPromise.setError();
+                                }
+                            });
+                        }
+                    } else if (initOptions.onLoad) {
+                        onLoad();
+                    } else {
+                        initPromise.setSuccess();
+                    }
+                } else {
+                    initPromise.setSuccess();
+                }
+            }
+
+            configPromise.success(processInit);
+            configPromise.error(function() {
+                promise.setError();
+            });
+
+            return promise.promise;
+        }
+
+        kc.login = function (options) {
+            return adapter.login(options);
+        }
+
+        kc.createLoginUrl = function(options) {
+            var state = createUUID();
+            var nonce = createUUID();
+
+            var redirectUri = adapter.redirectUri(options);
+
+            var callbackState = {
+                state: state,
+                nonce: nonce,
+                redirectUri: encodeURIComponent(redirectUri),
+            }
+
+            if (options && options.prompt) {
+                callbackState.prompt = options.prompt;
+            }
+
+            callbackStorage.add(callbackState);
+
+            var baseUrl;
+            if (options && options.action == 'register') {
+                baseUrl = kc.endpoints.register();
+            } else {
+                baseUrl = kc.endpoints.authorize();
+            }
+
+            var scope = (options && options.scope) ? "openid " + options.scope : "openid";
+
+            var url = baseUrl
+                + '?client_id=' + encodeURIComponent(kc.clientId)
+                + '&redirect_uri=' + encodeURIComponent(redirectUri)
+                + '&state=' + encodeURIComponent(state)
+                + '&response_mode=' + encodeURIComponent(kc.responseMode)
+                + '&response_type=' + encodeURIComponent(kc.responseType)
+                + '&scope=' + encodeURIComponent(scope);
+                if (useNonce) {
+                    url = url + '&nonce=' + encodeURIComponent(nonce);
+                }
+
+            if (options && options.prompt) {
+                url += '&prompt=' + encodeURIComponent(options.prompt);
+            }
+
+            if (options && options.maxAge) {
+                url += '&max_age=' + encodeURIComponent(options.maxAge);
+            }
+
+            if (options && options.loginHint) {
+                url += '&login_hint=' + encodeURIComponent(options.loginHint);
+            }
+
+            if (options && options.idpHint) {
+                url += '&kc_idp_hint=' + encodeURIComponent(options.idpHint);
+            }
+
+            if (options && options.locale) {
+                url += '&ui_locales=' + encodeURIComponent(options.locale);
+            }
+
+            return url;
+        }
+
+        kc.logout = function(options) {
+            return adapter.logout(options);
+        }
+
+        kc.createLogoutUrl = function(options) {
+            var url = kc.endpoints.logout()
+                + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options, false));
+
+            return url;
+        }
+
+        kc.register = function (options) {
+            return adapter.register(options);
+        }
+
+        kc.createRegisterUrl = function(options) {
+            if (!options) {
+                options = {};
+            }
+            options.action = 'register';
+            return kc.createLoginUrl(options);
+        }
+
+        kc.createAccountUrl = function(options) {
+            var realm = getRealmUrl();
+            var url = undefined;
+            if (typeof realm !== 'undefined') {
+                url = realm
+                + '/account'
+                + '?referrer=' + encodeURIComponent(kc.clientId)
+                + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
+            }
+            return url;
+        }
+
+        kc.accountManagement = function() {
+            return adapter.accountManagement();
+        }
+
+        kc.hasRealmRole = function (role) {
+            var access = kc.realmAccess;
+            return !!access && access.roles.indexOf(role) >= 0;
+        }
+
+        kc.hasResourceRole = function(role, resource) {
+            if (!kc.resourceAccess) {
+                return false;
+            }
+
+            var access = kc.resourceAccess[resource || kc.clientId];
+            return !!access && access.roles.indexOf(role) >= 0;
+        }
+
+        kc.loadUserProfile = function() {
+            var url = getRealmUrl() + '/account';
+            var req = new XMLHttpRequest();
+            req.open('GET', url, true);
+            req.setRequestHeader('Accept', 'application/json');
+            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+            var promise = createPromise();
+
+            req.onreadystatechange = function () {
+                if (req.readyState == 4) {
+                    if (req.status == 200) {
+                        kc.profile = JSON.parse(req.responseText);
+                        promise.setSuccess(kc.profile);
+                    } else {
+                        promise.setError();
+                    }
+                }
+            }
+
+            req.send();
+
+            return promise.promise;
+        }
+
+        kc.loadUserInfo = function() {
+            var url = kc.endpoints.userinfo();
+            var req = new XMLHttpRequest();
+            req.open('GET', url, true);
+            req.setRequestHeader('Accept', 'application/json');
+            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+            var promise = createPromise();
+
+            req.onreadystatechange = function () {
+                if (req.readyState == 4) {
+                    if (req.status == 200) {
+                        kc.userInfo = JSON.parse(req.responseText);
+                        promise.setSuccess(kc.userInfo);
+                    } else {
+                        promise.setError();
+                    }
+                }
+            }
+
+            req.send();
+
+            return promise.promise;
+        }
+
+        kc.isTokenExpired = function(minValidity) {
+            if (!kc.tokenParsed || (!kc.refreshToken && kc.flow != 'implicit' )) {
+                throw 'Not authenticated';
+            }
+
+            if (kc.timeSkew == null) {
+                console.info('[KEYCLOAK] Unable to determine if token is expired as timeskew is not set');
+                return true;
+            }
+
+            var expiresIn = kc.tokenParsed['exp'] - Math.ceil(new Date().getTime() / 1000) + kc.timeSkew;
+            if (minValidity) {
+                expiresIn -= minValidity;
+            }
+            return expiresIn < 0;
+        }
+
+        kc.updateToken = function(minValidity) {
+            var promise = createPromise();
+
+            if (!kc.refreshToken) {
+                promise.setError();
+                return promise.promise;
+            }
+
+            minValidity = minValidity || 5;
+
+            var exec = function() {
+                var refreshToken = false;
+                if (minValidity == -1) {
+                    refreshToken = true;
+                    console.info('[KEYCLOAK] Refreshing token: forced refresh');
+                } else if (!kc.tokenParsed || kc.isTokenExpired(minValidity)) {
+                    refreshToken = true;
+                    console.info('[KEYCLOAK] Refreshing token: token expired');
+                }
+
+                if (!refreshToken) {
+                    promise.setSuccess(false);
+                } else {
+                    var params = 'grant_type=refresh_token&' + 'refresh_token=' + kc.refreshToken;
+                    var url = kc.endpoints.token();
+
+                    refreshQueue.push(promise);
+
+                    if (refreshQueue.length == 1) {
+                        var req = new XMLHttpRequest();
+                        req.open('POST', url, true);
+                        req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                        req.withCredentials = true;
+
+                        if (kc.clientId && kc.clientSecret) {
+                            req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                        } else {
+                            params += '&client_id=' + encodeURIComponent(kc.clientId);
+                        }
+
+                        var timeLocal = new Date().getTime();
+
+                        req.onreadystatechange = function () {
+                            if (req.readyState == 4) {
+                                if (req.status == 200) {
+                                    console.info('[KEYCLOAK] Token refreshed');
+
+                                    timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                                    var tokenResponse = JSON.parse(req.responseText);
+
+                                    setToken(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], timeLocal);
+
+                                    kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
+                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                        p.setSuccess(true);
+                                    }
+                                } else {
+                                    console.warn('[KEYCLOAK] Failed to refresh token');
+
+                                    kc.onAuthRefreshError && kc.onAuthRefreshError();
+                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                        p.setError(true);
+                                    }
+                                }
+                            }
+                        };
+
+                        req.send(params);
+                    }
+                }
+            }
+
+            if (loginIframe.enable) {
+                var iframePromise = checkLoginIframe();
+                iframePromise.success(function() {
+                    exec();
+                }).error(function() {
+                    promise.setError();
+                });
+            } else {
+                exec();
+            }
+
+            return promise.promise;
+        }
+
+        kc.clearToken = function() {
+            if (kc.token) {
+                setToken(null, null, null);
+                kc.onAuthLogout && kc.onAuthLogout();
+                if (kc.loginRequired) {
+                    kc.login();
+                }
+            }
+        }
+
+        function getRealmUrl() {
+            if (typeof kc.authServerUrl !== 'undefined') {
+                if (kc.authServerUrl.charAt(kc.authServerUrl.length - 1) == '/') {
+                    return kc.authServerUrl + 'realms/' + encodeURIComponent(kc.realm);
+                } else {
+                    return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
+                }
+            } else {
+            	return undefined;
+            }
+        }
+
+        function getOrigin() {
+            if (!window.location.origin) {
+                return window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+            } else {
+                return window.location.origin;
+            }
+        }
+
+        function processCallback(oauth, promise) {
+            var code = oauth.code;
+            var error = oauth.error;
+            var prompt = oauth.prompt;
+
+            var timeLocal = new Date().getTime();
+
+            if (error) {
+                if (prompt != 'none') {
+                    var errorData = { error: error, error_description: oauth.error_description };
+                    kc.onAuthError && kc.onAuthError(errorData);
+                    promise && promise.setError(errorData);
+                } else {
+                    promise && promise.setSuccess();
+                }
+                return;
+            } else if ((kc.flow != 'standard') && (oauth.access_token || oauth.id_token)) {
+                authSuccess(oauth.access_token, null, oauth.id_token, true);
+            }
+
+            if ((kc.flow != 'implicit') && code) {
+                var params = 'code=' + code + '&grant_type=authorization_code';
+                var url = kc.endpoints.token();
+
+                var req = new XMLHttpRequest();
+                req.open('POST', url, true);
+                req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+                if (kc.clientId && kc.clientSecret) {
+                    req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                } else {
+                    params += '&client_id=' + encodeURIComponent(kc.clientId);
+                }
+
+                params += '&redirect_uri=' + oauth.redirectUri;
+
+                req.withCredentials = true;
+
+                req.onreadystatechange = function() {
+                    if (req.readyState == 4) {
+                        if (req.status == 200) {
+
+                            var tokenResponse = JSON.parse(req.responseText);
+                            authSuccess(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], kc.flow === 'standard');
+                        } else {
+                            var errorData = {};
+                            var json;
+                            try {
+                                json = JSON.parse(req.response);
+                            } catch(err) {
+                            }
+                            
+                            if (json &&
+                                    json.error) {
+                                errorData['error'] = json.error;
+                                if (json.error_description) {
+                                    errorData['error_description'] = json.error_description;
+                                }
+                                if (json.error_uri) {
+                                    errorData['error_uri'] = json.error_uri;
+                                }
+                            } else {
+                                errorData['error'] = 'invalid_request';
+                                var description = {
+                                	status: req.status,
+                                	response: req.responseText,
+                                };
+                                try {
+                                    var authHeader = req.getResponseHeader('WWW-Authenticate');
+                                    if (authHeader) {
+                                    	description['www_authenticate_header'] = authHeader;
+                                    }
+                                } catch(err) {}
+                                errorData['error_description'] = JSON.stringify(description);
+                            }
+                            kc.onAuthError && kc.onAuthError(errorData);
+                            promise && promise.setError(errorData);
+                        }
+                    }
+                };
+
+                req.send(params);
+            }
+
+            function authSuccess(accessToken, refreshToken, idToken, fulfillPromise) {
+                timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                setToken(accessToken, refreshToken, idToken, timeLocal);
+
+                if (useNonce && ((kc.tokenParsed && kc.tokenParsed.nonce != oauth.storedNonce) ||
+                    (kc.refreshTokenParsed && kc.refreshTokenParsed.nonce != oauth.storedNonce) ||
+                    (kc.idTokenParsed && kc.idTokenParsed.nonce != oauth.storedNonce))) {
+
+                    console.info('[KEYCLOAK] Invalid nonce, clearing token');
+                    kc.clearToken();
+                    promise && promise.setError();
+                } else {
+                    if (fulfillPromise) {
+                        kc.onAuthSuccess && kc.onAuthSuccess();
+                        promise && promise.setSuccess();
+                    }
+                }
+            }
+
+        }
+
+        function loadConfig(url) {
+            var promise = createPromise();
+            var configUrl;
+
+            if (!config) {
+                configUrl = 'keycloak.json';
+            } else if (typeof config === 'string') {
+                configUrl = config;
+            }
+
+            function setupOidcEndoints(oidcConfiguration) {
+                if (! oidcConfiguration) {
+                    kc.endpoints = {
+                        authorize: function() {
+                            return getRealmUrl() + '/protocol/openid-connect/auth';
+                        },
+                        token: function() {
+                            return getRealmUrl() + '/protocol/openid-connect/token';
+                        },
+                        logout: function() {
+                            return getRealmUrl() + '/protocol/openid-connect/logout';
+                        },
+                        checkSessionIframe: function() {
+                            return  getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html';
+                        },
+                        register: function() {
+                            return getRealmUrl() + '/protocol/openid-connect/registrations';
+                        },
+                        userinfo: function() {
+                            return getRealmUrl() + '/protocol/openid-connect/userinfo';
+                        }
+                    };
+                } else {
+                    kc.endpoints = {
+                        authorize: function() {
+                            return oidcConfiguration.authorization_endpoint;
+                        },
+                        token: function() {
+                            return oidcConfiguration.token_endpoint;
+                        },
+                        logout: function() {
+                            if (!oidcConfiguration.end_session_endpoint) {
+                                throw "Not supported by the OIDC server";
+                            }
+                            return oidcConfiguration.end_session_endpoint;
+                        },
+                        checkSessionIframe: function() {
+                            if (!oidcConfiguration.check_session_iframe) {
+                                throw "Not supported by the OIDC server";
+                            }
+                            return oidcConfiguration.check_session_iframe;
+                        },
+                        register: function() {
+                            throw 'Redirection to "Register user" page not supported in standard OIDC mode';
+                        },
+                        userinfo: function() {
+                            if (!oidcConfiguration.userinfo_endpoint) {
+                                throw "Not supported by the OIDC server";
+                            }
+                            return oidcConfiguration.userinfo_endpoint;
+                        }
+                    }
+                }
+            }
+
+            if (configUrl) {
+                var req = new XMLHttpRequest();
+                req.open('GET', configUrl, true);
+                req.setRequestHeader('Accept', 'application/json');
+
+                req.onreadystatechange = function () {
+                    if (req.readyState == 4) {
+                        if (req.status == 200 || fileLoaded(req)) {
+                            var config = JSON.parse(req.responseText);
+
+                            kc.authServerUrl = config['auth-server-url'];
+                            kc.realm = config['realm'];
+                            kc.clientId = config['resource'];
+                            kc.clientSecret = (config['credentials'] || {})['secret'];
+                            setupOidcEndoints(null);
+                            promise.setSuccess();
+                        } else {
+                            promise.setError();
+                        }
+                    }
+                };
+
+                req.send();
+            } else {
+                if (!config.clientId) {
+                    throw 'clientId missing';
+                }
+
+                kc.clientId = config.clientId;
+                kc.clientSecret = (config.credentials || {}).secret;
+
+                var oidcProvider = config['oidcProvider'];
+                if (!oidcProvider) {
+                    if (!config['url']) {
+                        var scripts = document.getElementsByTagName('script');
+                        for (var i = 0; i < scripts.length; i++) {
+                            if (scripts[i].src.match(/.*keycloak\.js/)) {
+                                config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
+                                break;
+                            }
+                        }
+                    }
+                    if (!config.realm) {
+                        throw 'realm missing';
+                    }
+
+                    kc.authServerUrl = config.url;
+                    kc.realm = config.realm;
+                    setupOidcEndoints(null);
+                    promise.setSuccess();
+                } else {
+                    if (typeof oidcProvider === 'string') {
+                        var oidcProviderConfigUrl;
+                        if (oidcProvider.charAt(oidcProvider.length - 1) == '/') {
+                            oidcProviderConfigUrl = oidcProvider + '.well-known/openid-configuration';
+                        } else {
+                            oidcProviderConfigUrl = oidcProvider + '/.well-known/openid-configuration';
+                        }
+                        var req = new XMLHttpRequest();
+                        req.open('GET', oidcProviderConfigUrl, true);
+                        req.setRequestHeader('Accept', 'application/json');
+
+                        req.onreadystatechange = function () {
+                            if (req.readyState == 4) {
+                                if (req.status == 200 || fileLoaded(req)) {
+                                    var oidcProviderConfig = JSON.parse(req.responseText);
+                                    setupOidcEndoints(oidcProviderConfig);
+                                    promise.setSuccess();
+                                } else {
+                                    promise.setError();
+                                }
+                            }
+                        };
+
+                        req.send();
+                    } else {
+                        setupOidcEndoints(oidcProvider);
+                        promise.setSuccess();
+                    }
+                }
+            }
+
+            return promise.promise;
+        }
+
+        function fileLoaded(xhr) {
+            return xhr.status == 0 && xhr.responseText && xhr.responseURL.startsWith('file:');
+        }
+
+        function setToken(token, refreshToken, idToken, timeLocal) {
+            if (kc.tokenTimeoutHandle) {
+                clearTimeout(kc.tokenTimeoutHandle);
+                kc.tokenTimeoutHandle = null;
+            }
+
+            if (refreshToken) {
+                kc.refreshToken = refreshToken;
+                kc.refreshTokenParsed = decodeToken(refreshToken);
+            } else {
+                delete kc.refreshToken;
+                delete kc.refreshTokenParsed;
+            }
+
+            if (idToken) {
+                kc.idToken = idToken;
+                kc.idTokenParsed = decodeToken(idToken);
+            } else {
+                delete kc.idToken;
+                delete kc.idTokenParsed;
+            }
+
+            if (token) {
+                kc.token = token;
+                kc.tokenParsed = decodeToken(token);
+                kc.sessionId = kc.tokenParsed.session_state;
+                kc.authenticated = true;
+                kc.subject = kc.tokenParsed.sub;
+                kc.realmAccess = kc.tokenParsed.realm_access;
+                kc.resourceAccess = kc.tokenParsed.resource_access;
+
+                if (timeLocal) {
+                    kc.timeSkew = Math.floor(timeLocal / 1000) - kc.tokenParsed.iat;
+                }
+
+                if (kc.timeSkew != null) {
+                    console.info('[KEYCLOAK] Estimated time difference between browser and server is ' + kc.timeSkew + ' seconds');
+
+                    if (kc.onTokenExpired) {
+                        var expiresIn = (kc.tokenParsed['exp'] - (new Date().getTime() / 1000) + kc.timeSkew) * 1000;
+                        console.info('[KEYCLOAK] Token expires in ' + Math.round(expiresIn / 1000) + ' s');
+                        if (expiresIn <= 0) {
+                            kc.onTokenExpired();
+                        } else {
+                            kc.tokenTimeoutHandle = setTimeout(kc.onTokenExpired, expiresIn);
+                        }
+                    }
+                }
+            } else {
+                delete kc.token;
+                delete kc.tokenParsed;
+                delete kc.subject;
+                delete kc.realmAccess;
+                delete kc.resourceAccess;
+
+                kc.authenticated = false;
+            }
+        }
+
+        function decodeToken(str) {
+            str = str.split('.')[1];
+
+            str = str.replace('/-/g', '+');
+            str = str.replace('/_/g', '/');
+            switch (str.length % 4)
+            {
+                case 0:
+                    break;
+                case 2:
+                    str += '==';
+                    break;
+                case 3:
+                    str += '=';
+                    break;
+                default:
+                    throw 'Invalid token';
+            }
+
+            str = (str + '===').slice(0, str.length + (str.length % 4));
+            str = str.replace(/-/g, '+').replace(/_/g, '/');
+
+            str = decodeURIComponent(escape(atob(str)));
+
+            str = JSON.parse(str);
+            return str;
+        }
+
+        function createUUID() {
+            var s = [];
+            var hexDigits = '0123456789abcdef';
+            for (var i = 0; i < 36; i++) {
+                s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
+            }
+            s[14] = '4';
+            s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
+            s[8] = s[13] = s[18] = s[23] = '-';
+            var uuid = s.join('');
+            return uuid;
+        }
+
+        kc.callback_id = 0;
+
+        function createCallbackId() {
+            var id = '<id: ' + (kc.callback_id++) + (Math.random()) + '>';
+            return id;
+
+        }
+
+        function parseCallback(url) {
+            var oauth = new CallbackParser(url, kc.responseMode).parseUri();
+            var oauthState = callbackStorage.get(oauth.state);
+
+            if (oauthState && (oauth.code || oauth.error || oauth.access_token || oauth.id_token)) {
+                oauth.redirectUri = oauthState.redirectUri;
+                oauth.storedNonce = oauthState.nonce;
+                oauth.prompt = oauthState.prompt;
+
+                if (oauth.fragment) {
+                    oauth.newUrl += '#' + oauth.fragment;
+                }
+
+                return oauth;
+            }
+        }
+
+        function createPromise() {
+            var p = {
+                setSuccess: function(result) {
+                    p.success = true;
+                    p.result = result;
+                    if (p.successCallback) {
+                        p.successCallback(result);
+                    }
+                },
+
+                setError: function(result) {
+                    p.error = true;
+                    p.result = result;
+                    if (p.errorCallback) {
+                        p.errorCallback(result);
+                    }
+                },
+
+                promise: {
+                    success: function(callback) {
+                        if (p.success) {
+                            callback(p.result);
+                        } else if (!p.error) {
+                            p.successCallback = callback;
+                        }
+                        return p.promise;
+                    },
+                    error: function(callback) {
+                        if (p.error) {
+                            callback(p.result);
+                        } else if (!p.success) {
+                            p.errorCallback = callback;
+                        }
+                        return p.promise;
+                    }
+                }
+            }
+            return p;
+        }
+
+        function setupCheckLoginIframe() {
+            var promise = createPromise();
+
+            if (!loginIframe.enable) {
+                promise.setSuccess();
+                return promise.promise;
+            }
+
+            if (loginIframe.iframe) {
+                promise.setSuccess();
+                return promise.promise;
+            }
+
+            var iframe = document.createElement('iframe');
+            loginIframe.iframe = iframe;
+
+            iframe.onload = function() {
+                var authUrl = kc.authorize();
+                if (authUrl.charAt(0) === '/') {
+                    loginIframe.iframeOrigin = getOrigin();
+                } else {
+                    loginIframe.iframeOrigin = authUrl.substring(0, authUrl.indexOf('/', 8));
+                }
+                promise.setSuccess();
+
+                setTimeout(check, loginIframe.interval * 1000);
+            }
+
+            var src = kc.checkSessionIframe();
+            iframe.setAttribute('src', src );
+            iframe.style.display = 'none';
+            document.body.appendChild(iframe);
+
+            var messageCallback = function(event) {
+                if ((event.origin !== loginIframe.iframeOrigin) || (loginIframe.iframe.contentWindow !== event.source)) {
+                    return;
+                }
+
+                if (!(event.data == 'unchanged' || event.data == 'changed' || event.data == 'error')) {
+                    return;
+                }
+
+
+                if (event.data != 'unchanged') {
+                    kc.clearToken();
+                }
+
+                var callbacks = loginIframe.callbackList.splice(0, loginIframe.callbackList.length);
+
+                for (var i = callbacks.length - 1; i >= 0; --i) {
+                    var promise = callbacks[i];
+                    if (event.data == 'unchanged') {
+                        promise.setSuccess();
+                    } else {
+                        promise.setError();
+                    }
+                }
+            };
+
+            window.addEventListener('message', messageCallback, false);
+
+            var check = function() {
+                checkLoginIframe();
+                if (kc.token) {
+                    setTimeout(check, loginIframe.interval * 1000);
+                }
+            };
+
+            return promise.promise;
+        }
+
+        function checkLoginIframe() {
+            var promise = createPromise();
+
+            if (loginIframe.iframe && loginIframe.iframeOrigin ) {
+                var msg = kc.clientId + ' ' + kc.sessionId;
+                loginIframe.callbackList.push(promise);
+                var origin = loginIframe.iframeOrigin;
+                if (loginIframe.callbackList.length == 1) {
+                    loginIframe.iframe.contentWindow.postMessage(msg, origin);
+                }
+            } else {
+                promise.setSuccess();
+            }
+
+            return promise.promise;
+        }
+
+        function loadAdapter(type) {
+            if (!type || type == 'default') {
+                return {
+                    login: function(options) {
+                        window.location.href = kc.createLoginUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    logout: function(options) {
+                        window.location.href = kc.createLogoutUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    register: function(options) {
+                        window.location.href = kc.createRegisterUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    accountManagement : function() {
+                        var accountUrl = kc.createAccountUrl();
+                        if (typeof accountUrl !== 'undefined') {
+                            window.location.href = accountUrl;
+                        } else {
+                            throw "Not supported by the OIDC server";
+                        }
+                        return createPromise().promise;
+                    },
+
+                    redirectUri: function(options, encodeHash) {
+                        if (arguments.length == 1) {
+                            encodeHash = true;
+                        }
+
+                        if (options && options.redirectUri) {
+                            return options.redirectUri;
+                        } else if (kc.redirectUri) {
+                            return kc.redirectUri;
+                        } else {
+                            var redirectUri = location.href;
+                            if (location.hash && encodeHash) {
+                                redirectUri = redirectUri.substring(0, location.href.indexOf('#'));
+                                redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'redirect_fragment=' + encodeURIComponent(location.hash.substring(1));
+                            }
+                            return redirectUri;
+                        }
+                    }
+                };
+            }
+
+            if (type == 'cordova') {
+                loginIframe.enable = false;
+
+                return {
+                    login: function(options) {
+                        var promise = createPromise();
+
+                        var o = 'location=no';
+                        if (options && options.prompt == 'none') {
+                            o += ',hidden=yes';
+                        }
+
+                        var loginUrl = kc.createLoginUrl(options);
+                        var ref = window.open(loginUrl, '_blank', o);
+
+                        var completed = false;
+
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                var callback = parseCallback(event.url);
+                                processCallback(callback, promise);
+                                ref.close();
+                                completed = true;
+                            }
+                        });
+
+                        ref.addEventListener('loaderror', function(event) {
+                            if (!completed) {
+                                if (event.url.indexOf('http://localhost') == 0) {
+                                    var callback = parseCallback(event.url);
+                                    processCallback(callback, promise);
+                                    ref.close();
+                                    completed = true;
+                                } else {
+                                    promise.setError();
+                                    ref.close();
+                                }
+                            }
+                        });
+
+                        return promise.promise;
+                    },
+
+                    logout: function(options) {
+                        var promise = createPromise();
+
+                        var logoutUrl = kc.createLogoutUrl(options);
+                        var ref = window.open(logoutUrl, '_blank', 'location=no,hidden=yes');
+
+                        var error;
+
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('loaderror', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            } else {
+                                error = true;
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('exit', function(event) {
+                            if (error) {
+                                promise.setError();
+                            } else {
+                                kc.clearToken();
+                                promise.setSuccess();
+                            }
+                        });
+
+                        return promise.promise;
+                    },
+
+                    register : function() {
+                        var registerUrl = kc.createRegisterUrl();
+                        var ref = window.open(registerUrl, '_blank', 'location=no');
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
+                    },
+
+                    accountManagement : function() {
+                        var accountUrl = kc.createAccountUrl();
+                        if (typeof accountUrl !== 'undefined') {
+                            var ref = window.open(accountUrl, '_blank', 'location=no');
+                            ref.addEventListener('loadstart', function(event) {
+                                if (event.url.indexOf('http://localhost') == 0) {
+                                    ref.close();
+                                }
+                            });
+                        } else {
+                            throw "Not supported by the OIDC server";
+                        }
+                    },
+
+                    redirectUri: function(options) {
+                        return 'http://localhost';
+                    }
+                }
+            }
+
+            throw 'invalid adapter type: ' + type;
+        }
+
+        var LocalStorage = function() {
+            if (!(this instanceof LocalStorage)) {
+                return new LocalStorage();
+            }
+
+            localStorage.setItem('kc-test', 'test');
+            localStorage.removeItem('kc-test');
+
+            var cs = this;
+
+            function clearExpired() {
+                var time = new Date().getTime();
+                for (var i = 0; i < localStorage.length; i++)  {
+                    var key = localStorage.key(i);
+                    if (key && key.indexOf('kc-callback-') == 0) {
+                        var value = localStorage.getItem(key);
+                        if (value) {
+                            try {
+                                var expires = JSON.parse(value).expires;
+                                if (!expires || expires < time) {
+                                    localStorage.removeItem(key);
+                                }
+                            } catch (err) {
+                                localStorage.removeItem(key);
+                            }
+                        }
+                    }
+                }
+            }
+
+            cs.get = function(state) {
+                if (!state) {
+                    return;
+                }
+
+                var key = 'kc-callback-' + state;
+                var value = localStorage.getItem(key);
+                if (value) {
+                    localStorage.removeItem(key);
+                    value = JSON.parse(value);
+                }
+
+                clearExpired();
+                return value;
+            };
+
+            cs.add = function(state) {
+                clearExpired();
+
+                var key = 'kc-callback-' + state.state;
+                state.expires = new Date().getTime() + (60 * 60 * 1000);
+                localStorage.setItem(key, JSON.stringify(state));
+            };
+        };
+
+        var CookieStorage = function() {
+            if (!(this instanceof CookieStorage)) {
+                return new CookieStorage();
+            }
+
+            var cs = this;
+
+            cs.get = function(state) {
+                if (!state) {
+                    return;
+                }
+
+                var value = getCookie('kc-callback-' + state);
+                setCookie('kc-callback-' + state, '', cookieExpiration(-100));
+                if (value) {
+                    return JSON.parse(value);
+                }
+            };
+
+            cs.add = function(state) {
+                setCookie('kc-callback-' + state.state, JSON.stringify(state), cookieExpiration(60));
+            };
+
+            cs.removeItem = function(key) {
+                setCookie(key, '', cookieExpiration(-100));
+            };
+
+            var cookieExpiration = function (minutes) {
+                var exp = new Date();
+                exp.setTime(exp.getTime() + (minutes*60*1000));
+                return exp;
+            };
+
+            var getCookie = function (key) {
+                var name = key + '=';
+                var ca = document.cookie.split(';');
+                for (var i = 0; i < ca.length; i++) {
+                    var c = ca[i];
+                    while (c.charAt(0) == ' ') {
+                        c = c.substring(1);
+                    }
+                    if (c.indexOf(name) == 0) {
+                        return c.substring(name.length, c.length);
+                    }
+                }
+                return '';
+            };
+
+            var setCookie = function (key, value, expirationDate) {
+                var cookie = key + '=' + value + '; '
+                    + 'expires=' + expirationDate.toUTCString() + '; ';
+                document.cookie = cookie;
+            }
+        };
+
+        function createCallbackStorage() {
+            try {
+                return new LocalStorage();
+            } catch (err) {
+            }
+
+            return new CookieStorage();
+        }
+
+        var CallbackParser = function(uriToParse, responseMode) {
+            if (!(this instanceof CallbackParser)) {
+                return new CallbackParser(uriToParse, responseMode);
+            }
+            var parser = this;
+
+            var initialParse = function() {
+                var baseUri = null;
+                var queryString = null;
+                var fragmentString = null;
+
+                var questionMarkIndex = uriToParse.indexOf("?");
+                var fragmentIndex = uriToParse.indexOf("#", questionMarkIndex + 1);
+                if (questionMarkIndex == -1 && fragmentIndex == -1) {
+                    baseUri = uriToParse;
+                } else if (questionMarkIndex != -1) {
+                    baseUri = uriToParse.substring(0, questionMarkIndex);
+                    queryString = uriToParse.substring(questionMarkIndex + 1);
+                    if (fragmentIndex != -1) {
+                        fragmentIndex = queryString.indexOf("#");
+                        fragmentString = queryString.substring(fragmentIndex + 1);
+                        queryString = queryString.substring(0, fragmentIndex);
+                    }
+                } else {
+                    baseUri = uriToParse.substring(0, fragmentIndex);
+                    fragmentString = uriToParse.substring(fragmentIndex + 1);
+                }
+
+                return { baseUri: baseUri, queryString: queryString, fragmentString: fragmentString };
+            }
+
+            var parseParams = function(paramString) {
+                var result = {};
+                var params = paramString.split('&');
+                for (var i = 0; i < params.length; i++) {
+                    var p = params[i].split('=');
+                    var paramName = decodeURIComponent(p[0]);
+                    var paramValue = decodeURIComponent(p[1]);
+                    result[paramName] = paramValue;
+                }
+                return result;
+            }
+
+            var handleQueryParam = function(paramName, paramValue, oauth) {
+                var supportedOAuthParams = [ 'code', 'state', 'error', 'error_description' ];
+
+                for (var i = 0 ; i< supportedOAuthParams.length ; i++) {
+                    if (paramName === supportedOAuthParams[i]) {
+                        oauth[paramName] = paramValue;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+
+            parser.parseUri = function() {
+                var parsedUri = initialParse();
+
+                var queryParams = {};
+                if (parsedUri.queryString) {
+                    queryParams = parseParams(parsedUri.queryString);
+                }
+
+                var oauth = { newUrl: parsedUri.baseUri };
+                for (var param in queryParams) {
+                    switch (param) {
+                        case 'redirect_fragment':
+                            oauth.fragment = queryParams[param];
+                            break;
+                        default:
+                            if (responseMode != 'query' || !handleQueryParam(param, queryParams[param], oauth)) {
+                                oauth.newUrl += (oauth.newUrl.indexOf('?') == -1 ? '?' : '&') + param + '=' + encodeURIComponent(queryParams[param]);
+                            }
+                            break;
+                    }
+                }
+
+                if (responseMode === 'fragment') {
+                    var fragmentParams = {};
+                    if (parsedUri.fragmentString) {
+                        fragmentParams = parseParams(parsedUri.fragmentString);
+                    }
+                    for (var param in fragmentParams) {
+                        oauth[param] = fragmentParams[param];
+                    }
+                }
+
+                return oauth;
+            }
+        }
+
+    }
+
+    if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+        module.exports = Keycloak;
+    } else {
+        window.Keycloak = Keycloak;
+
+        if ( typeof define === "function" && define.amd ) {
+            define( "keycloak", [], function () { return Keycloak; } );
+        }
+    }
+})( window );

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -18,10 +18,10 @@ const osio_msg_started = "<strong>Eclipse Che</strong> is loading";
 function provision_osio(redirect_uri) {
     var provisioningWindow = window.open('https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=' + encodeURIComponent(redirect_uri), 'osio_provisioning');
     if(! provisioningWindow) {
-    	setStatusMessage("User provisioning should happen in a separate window.<br/> \
-Please enable popups, before retrying");
+        setStatusMessage("User provisioning should happen in a separate window.<br/> \
+        Please enable popups, before retrying");
     } else {
-    	sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_provisioning);
+        sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_provisioning);
         sessionStorage.setItem('osio-provisioning', new Date().getTime());
         window.blur();
         window.focus();
@@ -35,92 +35,92 @@ var osioUserToApprove;
 
 function initAnalytics(writeKey){
 
-  // Create a queue, but don't obliterate an existing one!
-  var analytics = window.analytics = window.analytics || [];
+    // Create a queue, but don't obliterate an existing one!
+    var analytics = window.analytics = window.analytics || [];
 
-  // If the real analytics.js is already on the page return.
-  if (analytics.initialize) return;
+    // If the real analytics.js is already on the page return.
+    if (analytics.initialize) return;
 
-  // If the snippet was invoked already show an error.
-  if (analytics.invoked) {
-    if (window.console && console.error) {
-      console.error('Segment snippet included twice.');
+    // If the snippet was invoked already show an error.
+    if (analytics.invoked) {
+        if (window.console && console.error) {
+            console.error('Segment snippet included twice.');
+        }
+        return;
     }
-    return;
-  }
 
-  // Invoked flag, to make sure the snippet
-  // is never invoked twice.
-  analytics.invoked = true;
+    // Invoked flag, to make sure the snippet
+    // is never invoked twice.
+    analytics.invoked = true;
 
-  // A list of the methods in Analytics.js to stub.
-  analytics.methods = [
-    'trackSubmit',
-    'trackClick',
-    'trackLink',
-    'trackForm',
-    'pageview',
-    'identify',
-    'reset',
-    'group',
-    'track',
-    'ready',
-    'alias',
-    'debug',
-    'page',
-    'once',
-    'off',
-    'on'
-  ];
+    // A list of the methods in Analytics.js to stub.
+    analytics.methods = [
+        'trackSubmit',
+        'trackClick',
+        'trackLink',
+        'trackForm',
+        'pageview',
+        'identify',
+        'reset',
+        'group',
+        'track',
+        'ready',
+        'alias',
+        'debug',
+        'page',
+        'once',
+        'off',
+        'on'
+        ];
 
-  // Define a factory to create stubs. These are placeholders
-  // for methods in Analytics.js so that you never have to wait
-  // for it to load to actually record data. The `method` is
-  // stored as the first argument, so we can replay the data.
-  analytics.factory = function(method){
-    return function(){
-      var args = Array.prototype.slice.call(arguments);
-      args.unshift(method);
-      analytics.push(args);
-      return analytics;
+    // Define a factory to create stubs. These are placeholders
+    // for methods in Analytics.js so that you never have to wait
+    // for it to load to actually record data. The `method` is
+    // stored as the first argument, so we can replay the data.
+    analytics.factory = function(method){
+        return function(){
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(method);
+            analytics.push(args);
+            return analytics;
+        };
     };
-  };
 
-  // For each of our methods, generate a queueing stub.
-  for (var i = 0; i < analytics.methods.length; i++) {
-    var key = analytics.methods[i];
-    analytics[key] = analytics.factory(key);
-  }
+    // For each of our methods, generate a queueing stub.
+    for (var i = 0; i < analytics.methods.length; i++) {
+        var key = analytics.methods[i];
+        analytics[key] = analytics.factory(key);
+    }
 
-  // Define a method to load Analytics.js from our CDN,
-  // and that will be sure to only ever load it once.
-  analytics.load = function(key, options){
-    // Create an async script element based on your key.
-    var script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.async = true;
-    script.src = 'https://cdn.segment.com/analytics.js/v1/'
-      + key + '/analytics.min.js';
+    // Define a method to load Analytics.js from our CDN,
+    // and that will be sure to only ever load it once.
+    analytics.load = function(key, options){
+        // Create an async script element based on your key.
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.async = true;
+        script.src = 'https://cdn.segment.com/analytics.js/v1/'
+            + key + '/analytics.min.js';
 
-    // Insert our script next to the first script element.
-    var first = document.getElementsByTagName('script')[0];
-    first.parentNode.insertBefore(script, first);
-    analytics._loadOptions = options;
-  };
+        // Insert our script next to the first script element.
+        var first = document.getElementsByTagName('script')[0];
+        first.parentNode.insertBefore(script, first);
+        analytics._loadOptions = options;
+    };
 
-  // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.1.0';
+    // Add a version to keep track of what's in the wild.
+    analytics.SNIPPET_VERSION = '4.1.0';
 
-  // Load Analytics.js with your key, which will automatically
-  // load the tools you've enabled for your account. Boosh!
-  analytics.load(writeKey);
+    // Load Analytics.js with your key, which will automatically
+    // load the tools you've enabled for your account. Boosh!
+    analytics.load(writeKey);
 
-  return;
+    return;
 };
 
 (function( window, undefined ) {
     var osioURLSuffix;
-    
+
     if (window.location.host.includes('prod-preview')) {
         osioURLSuffix = 'prod-preview.openshift.io';
         osioProvisioningURL = "https://manage.openshift.com/openshiftio?cluster=starter-us-east-2a"
@@ -134,40 +134,40 @@ function initAnalytics(writeKey){
 
     function createPromise() {
         var p = {
-            setSuccess: function(result) {
-                p.success = true;
-                p.result = result;
-                if (p.successCallback) {
-                    p.successCallback(result);
-                }
-            },
-
-            setError: function(result) {
-                p.error = true;
-                p.result = result;
-                if (p.errorCallback) {
-                    p.errorCallback(result);
-                }
-            },
-
-            promise: {
-                success: function(callback) {
-                    if (p.success) {
-                        callback(p.result);
-                    } else if (!p.error) {
-                        p.successCallback = callback;
+                setSuccess: function(result) {
+                    p.success = true;
+                    p.result = result;
+                    if (p.successCallback) {
+                        p.successCallback(result);
                     }
-                    return p.promise;
                 },
-                error: function(callback) {
-                    if (p.error) {
-                        callback(p.result);
-                    } else if (!p.success) {
-                        p.errorCallback = callback;
+
+                setError: function(result) {
+                    p.error = true;
+                    p.result = result;
+                    if (p.errorCallback) {
+                        p.errorCallback(result);
                     }
-                    return p.promise;
+                },
+
+                promise: {
+                    success: function(callback) {
+                        if (p.success) {
+                            callback(p.result);
+                        } else if (!p.error) {
+                            p.successCallback = callback;
+                        }
+                        return p.promise;
+                    },
+                    error: function(callback) {
+                        if (p.error) {
+                            callback(p.result);
+                        } else if (!p.success) {
+                            p.errorCallback = callback;
+                        }
+                        return p.promise;
+                    }
                 }
-            }
         }
         return p;
     }
@@ -193,7 +193,7 @@ function initAnalytics(writeKey){
             request.send();
         });
     }
-    
+
     function performAccounkLinking(keycloak) {
         return get(osioApiURL + "/users?filter%5Busername%5D=" + encodeURIComponent(keycloak.tokenParsed.preferred_username), keycloak.token)
         .then((request) => {
@@ -209,7 +209,7 @@ function initAnalytics(writeKey){
             return get(osioAuthURL + "/token?for=" + encodeURIComponent(cluster), keycloak.token)
             .then((request) => {
                 sessionStorage.removeItem('osio-provisioning-notification-message');
-            	return request;
+                return request;
             },(request) => {
                 json = JSON.parse(request.responseText);
                 if (request.status == 401 &&
@@ -240,7 +240,7 @@ function initAnalytics(writeKey){
             });
         });
     }
-    
+
     function setUpNamespaces(keycloak) {
         return get(osioApiURL + "/user/services", keycloak.token)
         .catch(function (error) {
@@ -249,7 +249,7 @@ function initAnalytics(writeKey){
             return get(osioApiURL + "/user", keycloak.token)
             .then((request) => checkNamespacesCreated(keycloak, new Date().getTime() + 30000));
         });
-        
+
     }
 
     function checkNamespacesCreated(keycloak, timeLimit) {
@@ -271,83 +271,83 @@ function initAnalytics(writeKey){
     function identifyUser(keycloak) {
         return get("/api/fabric8-che-analytics/segment-write-key", keycloak.token)
         .then(function (request) {
-        	var segmentKey = request.responseText;
-        	initAnalytics(segmentKey);
-        	return get(osioApiURL + "/user", keycloak.token)
+            var segmentKey = request.responseText;
+            initAnalytics(segmentKey);
+            return get(osioApiURL + "/user", keycloak.token)
             .then((request) => {
-            	try {
-                	var json = JSON.parse(request.response);
+                try {
+                    var json = JSON.parse(request.response);
                     if (json && json.data) {
-                    	var user = json.data;
-                	    var traits = {
-                		        avatar: user.attributes.imageURL,
-                		        email: user.attributes.email,
-                		        username: user.attributes.username,
-                		        website: user.attributes.url,
-                		        name: user.attributes.fullName,
-                		        description: user.attributes.bio
-        		        }
-        			    if (localStorage['openshiftio.adobeMarketingCloudVisitorId']) {
-        		           traits.adobeMarketingCloudVisitorId = localStorage['openshiftio.adobeMarketingCloudVisitorId'];
-        		        }
-        		        analytics.identify(user.id, traits);
+                        var user = json.data;
+                        var traits = {
+                                avatar: user.attributes.imageURL,
+                                email: user.attributes.email,
+                                username: user.attributes.username,
+                                website: user.attributes.url,
+                                name: user.attributes.fullName,
+                                description: user.attributes.bio
+                        }
+                        if (localStorage['openshiftio.adobeMarketingCloudVisitorId']) {
+                            traits.adobeMarketingCloudVisitorId = localStorage['openshiftio.adobeMarketingCloudVisitorId'];
+                        }
+                        analytics.identify(user.id, traits);
                     }
-            	} catch(err) {}
+                } catch(err) {}
                 return request;
             })
             .catch(function(request) {
-            	return request;
+                return request;
             });
         })
         .catch(function(request) {
-        	return request;
+            return request;
         });
     }
-    
+
     function userNeedsApproval(error_description) {
-    	try {
-    		var data = JSON.parse(error_description);
-        	if (data && (data.status == 403 || data.status == 401)) {
+        try {
+            var data = JSON.parse(error_description);
+            if (data && (data.status == 403 || data.status == 401)) {
                 json = JSON.parse(data.response);
                 if (json &&
                         json.errors &&
                         json.errors[0]) {
                     var error = json.errors[0];
-                    
+
                     if(error.code == "unauthorized_error" &&
                             error.detail.endsWith("' is not approved")) {
-                            return error.detail.replace("' is not approved", "")
-                            .replace("user '", "");
+                        return error.detail.replace("' is not approved", "")
+                        .replace("user '", "");
                     }
                     if(error.code == "forbidden_error" &&
                             error.detail == "user is not authorized to access OpenShift") {
-                            return "unknown";
+                        return "unknown";
                     }
                 } 
-        	}
+            }
         } catch(err) {
         }
     }
-    
+
     var setStatusMessage;
-    
+
     var scripts = document.getElementsByTagName("script");
     var originalKeycloakScript;
     var provisioningPage;
     for(var i=0; i<scripts.length;++i) {
         if (scripts[i].src && scripts[i].src.endsWith("RhCheKeycloak.js")) {
-               originalKeycloakScript = scripts[i].src.replace("RhCheKeycloak.js", "OIDCKeycloak.js");
-               provisioningPage = scripts[i].src.replace("RhCheKeycloak.js", "provision.html");
-               console.log("originalKeycloakScript = ", originalKeycloakScript);
-               console.log("OSIO provisioning page = ", provisioningPage);
-               break;
+            originalKeycloakScript = scripts[i].src.replace("RhCheKeycloak.js", "OIDCKeycloak.js");
+            provisioningPage = scripts[i].src.replace("RhCheKeycloak.js", "provision.html");
+            console.log("originalKeycloakScript = ", originalKeycloakScript);
+            console.log("OSIO provisioning page = ", provisioningPage);
+            break;
         }
     }
 
     if (! originalKeycloakScript) {
         throw "Cannot find current script named 'RhCheKeycloak.js'";
     }
-    
+
     request = new XMLHttpRequest();
     request.open('GET', originalKeycloakScript, false);
     request.send();
@@ -370,126 +370,126 @@ function initAnalytics(writeKey){
                 var pageLoaderDiv = document.getElementsByClassName('ide-page-loader-content')[0];
                 var loaderImage = pageLoaderDiv.getElementsByTagName("img")[0];
                 if (loaderImage) {
-                	loaderImage.src = "/dashboard/assets/branding/loader.svg";
+                    loaderImage.src = "/dashboard/assets/branding/loader.svg";
                 }
-                
+
                 var statusDiv = document.createElement('div');
                 statusDiv.style = "text-align: center; position: fixed; top: 0; bottom: 0; left: 0; right: 0; margin: auto; height: 100%;";
                 statusDiv.innerHTML = '\
-                	<p id="osio-provisioning-status" style="position: relative; top: 50%; margin-top: 60px; font-weight: 500; font-size: larger; color: #bbb;"></p>';
+                    <p id="osio-provisioning-status" style="position: relative; top: 50%; margin-top: 60px; font-weight: 500; font-size: larger; color: #bbb;"></p>';
                 pageLoaderDiv.appendChild(statusDiv);
                 setStatusMessage = function(message) {
                     var messageToWrite;
                     lastOSIONotificationMessage = sessionStorage.getItem('osio-provisioning-notification-message');
                     if (lastOSIONotificationMessage) {
-                    	messageToWrite = lastOSIONotificationMessage;
+                        messageToWrite = lastOSIONotificationMessage;
                     } else {
-                    	messageToWrite = message;
+                        messageToWrite = message;
                     }
 
-                	document.getElementById("osio-provisioning-status").innerHTML = messageToWrite;
+                    document.getElementById("osio-provisioning-status").innerHTML = messageToWrite;
                 }
             } else {
                 setStatusMessage = function(message) {}
             }
-            
+
             setStatusMessage("");
-            
+
             var promise = originalInit(initOptions);
             promise.success(function(arg) {
                 var keycloak = kc;
-              var lastProvisioningDate = sessionStorage.getItem('osio-provisioning');
-              sessionStorage.removeItem('osio-provisioning');
-              var w = window.open('', 'osio_provisioning');
-              w && w.close();
-              identifyUser(keycloak)
-              .then(function() {
-            	  if (window.analytics && lastProvisioningDate) {
-            		  analytics.track('Provision User For Che');
-            	  }
-                  return performAccounkLinking(keycloak);
-              })
-              .then(()=>{
-                  return setUpNamespaces(keycloak);
-              })
-              .then(() => {
-        		  if (window.analytics && isInCheDashboard) {
-        			  analytics.track('Enter Che Dashboard');
-        		  }
-            	  setStatusMessage(osio_msg_started);
-                  finalPromise.setSuccess(arg);
-              })
-              .catch((errorMessage) => {
-            	  setStatusMessage(osio_msg_error_no_resources);
-                  finalPromise.setError({ error: 'invalid_request', error_description: errorMessage });
-              });
+                var lastProvisioningDate = sessionStorage.getItem('osio-provisioning');
+                sessionStorage.removeItem('osio-provisioning');
+                var w = window.open('', 'osio_provisioning');
+                w && w.close();
+                identifyUser(keycloak)
+                .then(function() {
+                    if (window.analytics && lastProvisioningDate) {
+                        analytics.track('Provision User For Che');
+                    }
+                    return performAccounkLinking(keycloak);
+                })
+                .then(()=>{
+                    return setUpNamespaces(keycloak);
+                })
+                .then(() => {
+                    if (window.analytics && isInCheDashboard) {
+                        analytics.track('Enter Che Dashboard');
+                    }
+                    setStatusMessage(osio_msg_started);
+                    finalPromise.setSuccess(arg);
+                })
+                .catch((errorMessage) => {
+                    setStatusMessage(osio_msg_error_no_resources);
+                    finalPromise.setError({ error: 'invalid_request', error_description: errorMessage });
+                });
             }).error(function(data) {
                 var keycloak = kc;
                 if (data && data.error_description) {
-                	osioUserToApprove = userNeedsApproval(data.error_description);
+                    osioUserToApprove = userNeedsApproval(data.error_description);
                 }
-                
+
                 if (osioUserToApprove) {
                     var lastProvisioningDate = sessionStorage.getItem('osio-provisioning');
                     var isProvisioning = false;
                     var provisioningTimeoutFailure = false;
                     if (lastProvisioningDate) {
-                      if (new Date().getTime() < parseInt(lastProvisioningDate) + 120000) {
-                          isProvisioning = true;
-                      } else {
-                              provisioningTimeoutFailure = true;
-                      }
+                        if (new Date().getTime() < parseInt(lastProvisioningDate) + 120000) {
+                            isProvisioning = true;
+                        } else {
+                            provisioningTimeoutFailure = true;
+                        }
                     }
-                    
-                    if (provisioningTimeoutFailure) {
-                      sessionStorage.removeItem('osio-provisioning');
-                      sessionStorage.removeItem('osio-provisioning-notification-message')
-                      setStatusMessage(osio_msg_error_no_resources);
-                      finalPromise.setError(data);
-                    } else {
-                      if (!isProvisioning) {
-                          get(provisioningPage)
-                          .then(function(request) {
-                          	var contentType = request.getResponseHeader('content-type');
-                      		if ( contentType && contentType.includes('html')) {
-                                  var provisioningMessageDiv = document.createElement('div');
-                                  provisioningMessageDiv.style = "height: 100%; z-index: 999; position:fixed; padding:0; margin:0; top:0; left:0; width: 100%; height: 100%; background:rgba(255,255,255,1);";
-                                  provisioningMessageDiv.innerHTML = '<iframe id="osio-provisioning-frame" style="border: 0px; width: 100%; height: 100%"></iframe>';
-                                  document.body.appendChild(provisioningMessageDiv);
 
-                                  var osioProvisioningFrameDocument = document.getElementById('osio-provisioning-frame').contentWindow.document
-                                  osioProvisioningFrameDocument.open();
-                                  osioProvisioningFrameDocument.write(request.responseText);
-                                  osioProvisioningFrameDocument.close();
-	                          	  if (osioUserToApprove != 'unknown') {
-	                        		  osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
-	                        	  }
-                      		} else {
-                      			  sessionStorage.removeItem('osio-provisioning-notification-message');
-                                  finalPromise.setError({ error: 'invalid_request', error_description: 'OSIO provisioning page loaded at URL: ' + provisioningPage + ' should be valid HTML' });
-                      		}
-                          }, function(request) {
-                  			  sessionStorage.removeItem('osio-provisioning-notification-message');
-                              finalPromise.setError({ error: 'invalid_request', error_description: "OSIO provisioning page could not be loaded at URL: " + provisioningPage });
-                          });
-                      } else {
+                    if (provisioningTimeoutFailure) {
+                        sessionStorage.removeItem('osio-provisioning');
+                        sessionStorage.removeItem('osio-provisioning-notification-message')
+                        setStatusMessage(osio_msg_error_no_resources);
+                        finalPromise.setError(data);
+                    } else {
+                        if (!isProvisioning) {
+                            get(provisioningPage)
+                            .then(function(request) {
+                                var contentType = request.getResponseHeader('content-type');
+                                if ( contentType && contentType.includes('html')) {
+                                    var provisioningMessageDiv = document.createElement('div');
+                                    provisioningMessageDiv.style = "height: 100%; z-index: 999; position:fixed; padding:0; margin:0; top:0; left:0; width: 100%; height: 100%; background:rgba(255,255,255,1);";
+                                    provisioningMessageDiv.innerHTML = '<iframe id="osio-provisioning-frame" style="border: 0px; width: 100%; height: 100%"></iframe>';
+                                    document.body.appendChild(provisioningMessageDiv);
+
+                                    var osioProvisioningFrameDocument = document.getElementById('osio-provisioning-frame').contentWindow.document
+                                    osioProvisioningFrameDocument.open();
+                                    osioProvisioningFrameDocument.write(request.responseText);
+                                    osioProvisioningFrameDocument.close();
+                                    if (osioUserToApprove != 'unknown') {
+                                        osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
+                                    }
+                                } else {
+                                    sessionStorage.removeItem('osio-provisioning-notification-message');
+                                    finalPromise.setError({ error: 'invalid_request', error_description: 'OSIO provisioning page loaded at URL: ' + provisioningPage + ' should be valid HTML' });
+                                }
+                            }, function(request) {
+                                sessionStorage.removeItem('osio-provisioning-notification-message');
+                                finalPromise.setError({ error: 'invalid_request', error_description: "OSIO provisioning page could not be loaded at URL: " + provisioningPage });
+                            });
+                        } else {
                             setStatusMessage(osio_msg_provisioning);
                             sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_provisioning);
                             setTimeout(function(){
                                 window.location.reload();
                             }, 1000);
-                      }
+                        }
                     }
                 } else {
-    			    sessionStorage.removeItem('osio-provisioning-notification-message');
-                	setStatusMessage("Error during authentication");
+                    sessionStorage.removeItem('osio-provisioning-notification-message');
+                    setStatusMessage("Error during authentication");
                     var w = window.open('', 'osio_provisioning');
                     w && w.close();
                     sessionStorage.removeItem('osio-provisioning');
                     finalPromise.setError(data);
                 }
             });
-            
+
             return finalPromise.promise;
         }
         return kc;

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -12,7 +12,7 @@
 const osio_msg_provisioning = "Creating your <strong>OpenShift</strong> account";
 const osio_msg_linking_account = "Linking your <strong>OpenShift</strong> account";
 const osio_msg_setting_up_namespaces = "Setting up your <strong>OpenShift.io</strong> environment";
-const osio_msg_error_no_resources = "Resources required to use <strong>Eclipse Che</strong> could not be granted to the user.<br>Please contact support.";
+const osio_msg_error_no_resources = "Resources required to use <strong>Eclipse Che</strong> could not be granted to the user.<br>You may want to <a href='' onclick='return osioProvisioningLogout()'>use a different account</a><br>or contact support.";
 const osio_msg_started = "<strong>Eclipse Che</strong> is loading";
 
 const telemetry_event_enter_che_dashboard = 'enter che dashboard';
@@ -473,10 +473,12 @@ function initAnalytics(writeKey){
                                     var osioProvisioningFrameDocument = document.getElementById('osio-provisioning-frame').contentWindow.document
                                     osioProvisioningFrameDocument.open();
                                     osioProvisioningFrameDocument.write(request.responseText);
-                                    osioProvisioningFrameDocument.close();
-                                    if (osioUserToApprove != 'unknown') {
-                                        osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
+                                    osioProvisioningFrameDocument.onload = function() {
+                                        if (osioUserToApprove != 'unknown') {
+                                            osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
+                                        }
                                     }
+                                    osioProvisioningFrameDocument.close();
                                 } else {
                                     sessionStorage.removeItem('osio-provisioning-notification-message');
                                     finalPromise.setError({ error: 'invalid_request', error_description: 'OSIO provisioning page loaded at URL: ' + provisioningPage + ' should be valid HTML' });

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -471,7 +471,7 @@ function initAnalytics(writeKey){
                                     document.body.appendChild(provisioningMessageDiv);
                                     var htmlContent;
                                     if (osioUserToApprove != 'unknown') {
-                                        htmlContent = request.responseText.replace('<span id="osio-user-placeholder"></span>', '<span id="osio-user-placeholder">' + osioUserToApprove + '</span>');
+                                        htmlContent = request.responseText.replace('<span id="osio-user-placeholder"></span>', '<span id="osio-user-placeholder">, ' + osioUserToApprove + '</span>');
                                     } else {
                                         htmlContent = request.responseText;
                                     }

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -469,15 +469,15 @@ function initAnalytics(writeKey){
                                     provisioningMessageDiv.style = "height: 100%; z-index: 999; position:fixed; padding:0; margin:0; top:0; left:0; width: 100%; height: 100%; background:rgba(255,255,255,1);";
                                     provisioningMessageDiv.innerHTML = '<iframe id="osio-provisioning-frame" style="border: 0px; width: 100%; height: 100%"></iframe>';
                                     document.body.appendChild(provisioningMessageDiv);
-
+                                    var htmlContent;
+                                    if (osioUserToApprove != 'unknown') {
+                                        htmlContent = request.responseText.replace('<span id="osio-user-placeholder"></span>', '<span id="osio-user-placeholder">' + osioUserToApprove + '</span>');
+                                    } else {
+                                        htmlContent = request.responseText;
+                                    }
                                     var osioProvisioningFrameDocument = document.getElementById('osio-provisioning-frame').contentWindow.document
                                     osioProvisioningFrameDocument.open();
-                                    osioProvisioningFrameDocument.write(request.responseText);
-                                    osioProvisioningFrameDocument.onload = function() {
-                                        if (osioUserToApprove != 'unknown') {
-                                            osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
-                                        }
-                                    }
+                                    osioProvisioningFrameDocument.write(htmlContent);
                                     osioProvisioningFrameDocument.close();
                                 } else {
                                     sessionStorage.removeItem('osio-provisioning-notification-message');

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -411,8 +411,10 @@ function initAnalytics(writeKey){
                 var keycloak = kc;
                 var lastProvisioningDate = sessionStorage.getItem('osio-provisioning');
                 sessionStorage.removeItem('osio-provisioning');
-                var w = window.open('', 'osio_provisioning');
-                w && w.close();
+                if (lastProvisioningDate) {
+                    var w = window.open('', 'osio_provisioning');
+                    w && w.close();
+                }
                 identifyUser(keycloak)
                 .then(function() {
                     if (window.analytics && lastProvisioningDate) {
@@ -492,11 +494,9 @@ function initAnalytics(writeKey){
                         }
                     }
                 } else {
+                    sessionStorage.removeItem('osio-provisioning');
                     sessionStorage.removeItem('osio-provisioning-notification-message');
                     setStatusMessage("Error during authentication");
-                    var w = window.open('', 'osio_provisioning');
-                    w && w.close();
-                    sessionStorage.removeItem('osio-provisioning');
                     finalPromise.setError(data);
                 }
             });

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -119,18 +119,8 @@ function initAnalytics(writeKey){
 };
 
 (function( window, undefined ) {
-    var osioURLSuffix;
-
-    if (window.location.host.includes('prod-preview')) {
-        osioURLSuffix = 'prod-preview.openshift.io';
-        osioProvisioningURL = "https://manage.openshift.com/openshiftio?cluster=starter-us-east-2a"
-    } else {
-        osioURLSuffix = 'openshift.io';
-        osioProvisioningURL = "https://manage.openshift.com/register/openshiftio_create"
-    }
-
-    var osioApiURL = 'https://api.' + osioURLSuffix + '/api';
-    var osioAuthURL = 'https://auth.' + osioURLSuffix + '/api';
+    var osioApiURL;
+    var osioAuthURL;
 
     function createPromise() {
         var p = {
@@ -357,6 +347,20 @@ function initAnalytics(writeKey){
     var originalKeycloak = window.Keycloak;
     window.Keycloak = function(config) {
         kc = originalKeycloak(config);
+        if (config && !config.oidcProvider) {
+            return kc;
+        }
+        
+        var osioAuthURL = config.oidcProvider;
+        
+        if (osioAuthURL.includes('.prod-preview.')) {
+            osioApiURL = 'https://api.prod-preview.openshift.io/api';
+            osioProvisioningURL = "https://manage.openshift.com/openshiftio?cluster=starter-us-east-2a";
+        } else {
+            osioApiURL = 'https://api.openshift.io/api';
+            osioProvisioningURL = "https://manage.openshift.com/register/openshiftio_create";
+        }
+
         osioProvisioningLogout = function() {
             kc.logout();
             return false;

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+const osio_msg_provisioning = "Creating your <strong>OpenShift</strong> account";
+const osio_msg_linking_account = "Linking your <strong>OpenShift</strong> account";
+const osio_msg_setting_up_namespaces = "Setting up your <strong>OpenShift.io</strong> environment";
+const osio_msg_error_no_resources = "Resources required to use <strong>Eclipse Che</strong> could not be granted to the user.<br>Please contact support.";
+const osio_msg_started = "<strong>Eclipse Che</strong> is loading";
+
+function provision_osio(redirect_uri) {
+    var provisioningWindow = window.open('https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=' + encodeURIComponent(redirect_uri), 'osio_provisioning');
+    if(! provisioningWindow) {
+    	setStatusMessage("User provisioning should happen in a separate window.<br/> \
+Please enable popups, before retrying");
+    } else {
+    	sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_provisioning);
+        sessionStorage.setItem('osio-provisioning', new Date().getTime());
+        window.blur();
+        window.focus();
+        window.location.reload();
+    }
+}
+
+var osioProvisioningLogout;
+var osioProvisioningURL;
+var osioUserToApprove;
+
+(function( window, undefined ) {
+    var osioURLSuffix;
+    
+    if (window.location.host.includes('prod-preview')) {
+        osioURLSuffix = 'prod-preview.openshift.io';
+        osioProvisioningURL = "https://manage.openshift.com/openshiftio?cluster=starter-us-east-2a"
+    } else {
+        osioURLSuffix = 'openshift.io';
+        osioProvisioningURL = "https://manage.openshift.com/register/openshiftio_create"
+    }
+
+    var osioApiURL = 'https://api.' + osioURLSuffix + '/api';
+    var osioAuthURL = 'https://auth.' + osioURLSuffix + '/api';
+
+    function createPromise() {
+        var p = {
+            setSuccess: function(result) {
+                p.success = true;
+                p.result = result;
+                if (p.successCallback) {
+                    p.successCallback(result);
+                }
+            },
+
+            setError: function(result) {
+                p.error = true;
+                p.result = result;
+                if (p.errorCallback) {
+                    p.errorCallback(result);
+                }
+            },
+
+            promise: {
+                success: function(callback) {
+                    if (p.success) {
+                        callback(p.result);
+                    } else if (!p.error) {
+                        p.successCallback = callback;
+                    }
+                    return p.promise;
+                },
+                error: function(callback) {
+                    if (p.error) {
+                        callback(p.result);
+                    } else if (!p.success) {
+                        p.errorCallback = callback;
+                    }
+                    return p.promise;
+                }
+            }
+        }
+        return p;
+    }
+
+    function get(url, token) {
+        return new Promise((resolve, reject) => {
+            var request = new XMLHttpRequest();
+            request.onerror = request.onabort = function(error) {
+                reject(error);
+            };
+            request.onload = function() {
+                if (request.status == 200) {
+                    resolve(this)
+                } else {
+                    reject(this);
+                }
+            };
+
+            request.open("GET", url, true);
+            if (token) {
+                request.setRequestHeader("Authorization", "Bearer " + token);
+            }
+            request.send();
+        });
+    }
+    
+    function performAccounkLinking(keycloak) {
+        return get(osioApiURL + "/users?filter%5Busername%5D=" + encodeURIComponent(keycloak.tokenParsed.preferred_username), keycloak.token)
+        .then((request) => {
+            data = JSON.parse(request.responseText).data;
+            if (data && data[0]) {
+                return data[0].attributes.cluster;
+            } else {
+                sessionStorage.removeItem('osio-provisioning-notification-message');
+                return Promise.reject("cannot find cluster for user: " + keycloak.tokenParsed.preferred_username)
+            }
+        })
+        .then((cluster) => {
+            return get(osioAuthURL + "/token?for=" + encodeURIComponent(cluster), keycloak.token)
+            .then((request) => {
+                sessionStorage.removeItem('osio-provisioning-notification-message');
+            	return request;
+            },(request) => {
+                json = JSON.parse(request.responseText);
+                if (request.status == 401 &&
+                        json &&
+                        json.errors &&
+                        json.errors[0] &&
+                        json.errors[0].detail == "token is missing") {
+                    sessionStorage.removeItem('osio-provisioning-notification-message');
+                    setStatusMessage(osio_msg_linking_account);
+                    return get(osioAuthURL + "/token/link?for=" + encodeURIComponent(cluster) + "&redirect=" + encodeURIComponent(window.location), keycloak.token)
+                    .then((request) => {
+                        var json = JSON.parse(request.responseText);
+                        if (json && json.redirect_location) {
+                            sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_linking_account);
+                            window.location.replace(json.redirect_location);
+                            return Promise.reject("Will redirect the page");
+                        } else {
+                            sessionStorage.removeItem('osio-provisioning-notification-message');
+                            return Promise.reject("Cannot get account linking page for user: " + keycloak.tokenParsed.preferred_username)
+                        }
+                    });
+                } else {
+                    console.log("Error while checking account linking", request);
+                    setStatusMessage("Error while checking account linking");
+                    sessionStorage.removeItem('osio-provisioning-notification-message');
+                    return Promise.reject("Error while checking account linking: " + request.responseText);
+                }
+            });
+        });
+    }
+    
+    function setUpNamespaces(keycloak) {
+        return get(osioApiURL + "/user/services", keycloak.token)
+        .catch(function (error) {
+            sessionStorage.removeItem('osio-provisioning-notification-message');
+            setStatusMessage(osio_msg_setting_up_namespaces);
+            return get(osioApiURL + "/user", keycloak.token)
+            .then((request) => checkNamespacesCreated(keycloak, new Date().getTime() + 30000));
+        });
+        
+    }
+
+    function checkNamespacesCreated(keycloak, timeLimit) {
+        setStatusMessage(osio_msg_setting_up_namespaces);
+        return get(osioApiURL + "/user/services", keycloak.token)
+        .catch((request) => {
+            if (new Date().getTime() < timeLimit) {
+                return new Promise((resolve, reject) => {
+                    setTimeout(function(){
+                        resolve(checkNamespacesCreated(keycloak, timeLimit));
+                    }, 2000);
+                })
+            } else {
+                return Promise.reject("Error when checking namespaces: " + request.responseText);
+            }
+        });
+    }
+    
+    function userNeedsApproval(error_description) {
+    	try {
+    		var data = JSON.parse(error_description);
+        	if (data && (data.status == 403 || data.status == 401)) {
+                json = JSON.parse(data.response);
+                if (json &&
+                        json.errors &&
+                        json.errors[0]) {
+                    var error = json.errors[0];
+                    
+                    if(error.code == "unauthorized_error" &&
+                            error.detail.endsWith("' is not approved")) {
+                            return error.detail.replace("' is not approved", "")
+                            .replace("user '", "");
+                    }
+                    if(error.code == "forbidden_error" &&
+                            error.detail == "user is not authorized to access OpenShift") {
+                            return "unknown";
+                    }
+                } 
+        	}
+        } catch(err) {
+        }
+    }
+    
+    var setStatusMessage;
+    
+    var scripts = document.getElementsByTagName("script");
+    var originalKeycloakScript;
+    var provisioningPage;
+    for(var i=0; i<scripts.length;++i) {
+        if (scripts[i].src && scripts[i].src.endsWith("RhCheKeycloak.js")) {
+               originalKeycloakScript = scripts[i].src.replace("RhCheKeycloak.js", "OIDCKeycloak.js");
+               provisioningPage = scripts[i].src.replace("RhCheKeycloak.js", "provision.html");
+               console.log("originalKeycloakScript = ", originalKeycloakScript);
+               console.log("OSIO provisioning page = ", provisioningPage);
+               break;
+        }
+    }
+
+    if (! originalKeycloakScript) {
+        throw "Cannot find current script named 'RhCheKeycloak.js'";
+    }
+    
+    request = new XMLHttpRequest();
+    request.open('GET', originalKeycloakScript, false);
+    request.send();
+
+    source = request.responseText;
+    eval(source);
+    var originalKeycloak = window.Keycloak;
+    window.Keycloak = function(config) {
+        kc = originalKeycloak(config);
+        osioProvisioningLogout = function() {
+            kc.logout();
+            return false;
+        };
+        var originalInit = kc.init;
+        kc.init = function (initOptions) {
+            var finalPromise = createPromise();
+
+            if (document.getElementsByClassName('ide-page-loader-content').length > 0) {
+                var pageLoaderDiv = document.getElementsByClassName('ide-page-loader-content')[0];
+                var loaderImage = pageLoaderDiv.getElementsByTagName("img")[0];
+                if (loaderImage) {
+                	loaderImage.src = "/dashboard/assets/branding/loader.svg";
+                }
+                
+                var statusDiv = document.createElement('div');
+                statusDiv.style = "text-align: center; position: fixed; top: 0; bottom: 0; left: 0; right: 0; margin: auto; height: 100%;";
+                statusDiv.innerHTML = '\
+                	<p id="osio-provisioning-status" style="position: relative; top: 50%; margin-top: 60px; font-weight: 500; font-size: larger; color: #bbb;"></p>';
+                pageLoaderDiv.appendChild(statusDiv);
+                setStatusMessage = function(message) {
+                    var messageToWrite;
+                    lastOSIONotificationMessage = sessionStorage.getItem('osio-provisioning-notification-message');
+                    if (lastOSIONotificationMessage) {
+                    	messageToWrite = lastOSIONotificationMessage;
+                    } else {
+                    	messageToWrite = message;
+                    }
+
+                	document.getElementById("osio-provisioning-status").innerHTML = messageToWrite;
+                }
+            } else {
+                setStatusMessage = function(message) {}
+            }
+            
+            setStatusMessage("");
+            
+            var promise = originalInit(initOptions);
+            promise.success(function(arg) {
+                var keycloak = kc;
+              sessionStorage.removeItem('osio-provisioning');
+              var w = window.open('', 'osio_provisioning');
+              w && w.close();
+              performAccounkLinking(keycloak)
+              .then(()=>{
+                  return setUpNamespaces(keycloak);
+              })
+              .then(() => {
+            	  setStatusMessage(osio_msg_started);
+                  finalPromise.setSuccess(arg);
+              })
+              .catch((errorMessage) => {
+            	  setStatusMessage(osio_msg_error_no_resources);
+                  finalPromise.setError({ error: 'invalid_request', error_description: errorMessage });
+              });
+            }).error(function(data) {
+                var keycloak = kc;
+                if (data && data.error_description) {
+                	osioUserToApprove = userNeedsApproval(data.error_description);
+                }
+                
+                if (osioUserToApprove) {
+                    var lastProvisioningDate = sessionStorage.getItem('osio-provisioning');
+                    var isProvisioning = false;
+                    var provisioningTimeoutFailure = false;
+                    if (lastProvisioningDate) {
+                      if (new Date().getTime() < parseInt(lastProvisioningDate) + 120000) {
+                          isProvisioning = true;
+                      } else {
+                              provisioningTimeoutFailure = true;
+                      }
+                    }
+                    
+                    if (provisioningTimeoutFailure) {
+                      sessionStorage.removeItem('osio-provisioning');
+                      sessionStorage.removeItem('osio-provisioning-notification-message')
+                      setStatusMessage(osio_msg_error_no_resources);
+                      finalPromise.setError(data);
+                    } else {
+                      if (!isProvisioning) {
+                          get(provisioningPage)
+                          .then(function(request) {
+                          	var contentType = request.getResponseHeader('content-type');
+                      		if ( contentType && contentType.includes('html')) {
+                                  var provisioningMessageDiv = document.createElement('div');
+                                  provisioningMessageDiv.style = "height: 100%; z-index: 999; position:fixed; padding:0; margin:0; top:0; left:0; width: 100%; height: 100%; background:rgba(255,255,255,1);";
+                                  provisioningMessageDiv.innerHTML = '<iframe id="osio-provisioning-frame" style="border: 0px; width: 100%; height: 100%"></iframe>';
+                                  document.body.appendChild(provisioningMessageDiv);
+
+                                  var osioProvisioningFrameDocument = document.getElementById('osio-provisioning-frame').contentWindow.document
+                                  osioProvisioningFrameDocument.open();
+                                  osioProvisioningFrameDocument.write(request.responseText);
+                                  osioProvisioningFrameDocument.close();
+	                          	  if (osioUserToApprove != 'unknown') {
+	                        		  osioProvisioningFrameDocument.getElementById('osio-user-placeholder').innerHTML=", " + osioUserToApprove;
+	                        	  }
+                      		} else {
+                      			  sessionStorage.removeItem('osio-provisioning-notification-message');
+                                  finalPromise.setError({ error: 'invalid_request', error_description: 'OSIO provisioning page loaded at URL: ' + provisioningPage + ' should be valid HTML' });
+                      		}
+                          }, function(request) {
+                  			  sessionStorage.removeItem('osio-provisioning-notification-message');
+                              finalPromise.setError({ error: 'invalid_request', error_description: "OSIO provisioning page could not be loaded at URL: " + provisioningPage });
+                          });
+                      } else {
+                            setStatusMessage(osio_msg_provisioning);
+                            sessionStorage.setItem('osio-provisioning-notification-message', osio_msg_provisioning);
+                            setTimeout(function(){
+                                window.location.reload();
+                            }, 1000);
+                      }
+                    }
+                } else {
+    			    sessionStorage.removeItem('osio-provisioning-notification-message');
+                	setStatusMessage("Error during authentication");
+                    var w = window.open('', 'osio_provisioning');
+                    w && w.close();
+                    sessionStorage.removeItem('osio-provisioning');
+                    finalPromise.setError(data);
+                }
+            });
+            
+            return finalPromise.promise;
+        }
+        return kc;
+    }
+})( window );

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -312,9 +312,13 @@ function initAnalytics(writeKey){
                         return error.detail.replace("' is not approved", "")
                         .replace("user '", "");
                     }
-                    if(error.code == "forbidden_error" &&
-                            error.detail == "user is not authorized to access OpenShift") {
-                        return "unknown";
+                    if(error.code == "forbidden_error" && error.detail
+                            && error.detail.startsWith("user is not authorized to access OpenShift")) {
+                        if (error.detail.startsWith("user is not authorized to access OpenShift: ")) {
+                            return error.detail.replace("user is not authorized to access OpenShift: ", "");
+                        } else {
+                            return "unknown";
+                        }
                     }
                 } 
             }

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/RhCheKeycloak.js
@@ -15,6 +15,9 @@ const osio_msg_setting_up_namespaces = "Setting up your <strong>OpenShift.io</st
 const osio_msg_error_no_resources = "Resources required to use <strong>Eclipse Che</strong> could not be granted to the user.<br>Please contact support.";
 const osio_msg_started = "<strong>Eclipse Che</strong> is loading";
 
+const telemetry_event_enter_che_dashboard = 'enter che dashboard';
+const telemetry_event_provision_user_for_che = 'provision user for che';
+
 function provision_osio(redirect_uri) {
     var provisioningWindow = window.open('https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=' + encodeURIComponent(redirect_uri), 'osio_provisioning');
     if(! provisioningWindow) {
@@ -351,7 +354,7 @@ function initAnalytics(writeKey){
             return kc;
         }
         
-        var osioAuthURL = config.oidcProvider;
+        osioAuthURL = config.oidcProvider;
         
         if (osioAuthURL.includes('.prod-preview.')) {
             osioApiURL = 'https://api.prod-preview.openshift.io/api';
@@ -409,7 +412,7 @@ function initAnalytics(writeKey){
                 identifyUser(keycloak)
                 .then(function() {
                     if (window.analytics && lastProvisioningDate) {
-                        analytics.track('Provision User For Che');
+                        analytics.track(telemetry_event_provision_user_for_che);
                     }
                     return performAccounkLinking(keycloak);
                 })
@@ -418,7 +421,7 @@ function initAnalytics(writeKey){
                 })
                 .then(() => {
                     if (window.analytics && isInCheDashboard) {
-                        analytics.track('Enter Che Dashboard');
+                        analytics.track(telemetry_event_enter_che_dashboard);
                     }
                     setStatusMessage(osio_msg_started);
                     finalPromise.setSuccess(arg);

--- a/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/provision.html
+++ b/assembly/fabric8-ide-gwt-app/src/main/resources/org/eclipse/che/public/keycloak/provision.html
@@ -1,0 +1,188 @@
+<!--
+
+    Copyright (c) 2016-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<html class="" lang="en">
+<head class="at-element-marker">
+<!--[if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/ie8/0.4.1/ie8.js" ></script><![endif]-->
+<title>Welcome to Eclipse Che</title>
+
+<style id="at-mbox-default-style" type="text/css">
+.mboxDefault {
+	visibility: hidden;
+}
+</style>
+<style type="text/css">
+.at-element-marker {
+	visibility: visible;
+}
+</style>
+
+<meta name="robots" content="nofollow">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+
+<!-- RHD css start -->
+<link rel="stylesheet" type="text/css"
+  href="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/css/app-20180411.css">
+<link rel="stylesheet"
+  href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css">
+<!--[if lt IE 9]><script type="text/javascript" src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+<!-- RHD css end -->
+
+<link
+  href="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/css/login-v5.css?v=3.4.11"
+  rel="stylesheet">
+<link
+  href="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/css/login-oio-v1.css?v=3.4.11"
+  rel="stylesheet">
+
+<!-- Common JS -->
+<script
+  src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/js/vendor/jquery-20180411.js?v=3.4.11"
+  type="text/javascript"></script>
+<script
+  src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/js/vendor/modernizr-custom-20180411.js?v=3.4.11"
+  type="text/javascript"></script>
+<script
+  src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/js/vendor/jquery.validate.min.js?v=3.4.11"
+  type="text/javascript"></script>
+<script
+  src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/js/vendor/hideShowPassword.js?v=3.4.11"
+  type="text/javascript"></script>
+</head>
+
+<body class="home fullbleed " style="">
+  <div class="site-wrapper at-element-marker">
+    <header class="main clearfix at-element-marker">
+      <div class="row header-wrap">
+        <div class="logo-wrap">
+          <div class="logo">
+            <a href="http://www.openshift.io"
+              title="Red Hat OpenShift.io"><img
+              src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/img/OpenShift-io_logo.svg"
+              alt="Red Hat OpenShift.io"></a>
+          </div>
+        </div>
+      </div>
+    </header>
+    <div class="wrapper clearfix">
+      <div class="content-wrapper">
+        <div class="row content">
+          <div class="large-24 columns">
+
+
+            <div id="kc-content" class="">
+              <div id="kc-content-wrapper" class="">
+                <div id="kc-form" class="">
+                  <div id="kc-form-wrapper" class="">
+                    <style type="text/css">
+.content-wrapper, .wrapper {
+	background-color: #f9f9f9 !important;
+}
+</style>
+                    <div class="kc-loginpage">
+                      <div class="row content login-main-row">
+                        <div class="kc-wrapper">
+                          <div class="kc-card">
+                            <h1>
+                              <div class="centered download-hide">Welcome to Eclipse Che</div>
+                            </h1>
+                            <div class="centered download-hide">
+                              <p>
+                                <b>Eclipse Che powered by OpenShift.</b>
+                                <br><br>
+                                We’re glad you are here<span id="osio-user-placeholder"></span>.
+                                <br><br>
+                                <b>Ready to go ?</b><br><br>
+                                Please activate your account by clicking
+                                on the link below.<br>
+                                We’ll confirm your account login again and grant you the resources to use Eclipse Che. 
+                              </p> <!-- Log in with the Red Hat account that you used when you signed up --> 
+                            </div>
+                            <div class="field">
+                                <div id="kc-form-buttons" class=" row collapse">
+                                    <div class="large-24 columns">
+                                        <button class="download-hide button heavy-cta large" name="login" onclick="parent.provision_osio(parent.osioProvisioningURL)">Activate Account</button>
+                                    </div>
+                                </div>
+                            </div>
+                          </div>
+                          <span class="new-account"><a href="" onclick="return parent.osioProvisioningLogout()">Use a different account</a></span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="clearfix"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- / .content-wrapper -->
+    </div>
+    <!-- / .top-page-wrap -->
+
+    <footer class="bottom">
+      <section class="footer-legal">
+        <div class="legal">
+          <div class="row">
+            <div class="medium-5 small-24 columns">
+              <a href="https://www.redhat.com/" target="_blank"
+                rel="noopener noreferrer"><img alt="Red Hat"
+                class="rh-logo"
+                src="https://developers.redhat.com/themes/custom/rhdp/images/branding/RHLogo_white.svg"></a>
+            </div>
+            <div class="medium-15 columns">
+              <ul class="inline-list">
+                <li><a class="copyright">Copyright © 2018 Red
+                    Hat Inc.</a></li>
+                <li><a
+                  href="http://www.redhat.com/en/about/privacy-policy"
+                  target="_blank" rel="noopener noreferrer">Privacy
+                    statement</a></li>
+                <li><a
+                  href="http://www.redhat.com/en/about/terms-use"
+                  target="_blank" rel="noopener noreferrer">Terms of
+                    use</a></li>
+                <li><a
+                  href="http://www.redhat.com/en/about/all-policies-guidelines"
+                  target="_blank" rel="noopener noreferrer">All
+                    policies and guidelines</a></li>
+              </ul>
+            </div>
+            <div class="medium-4 small-24 right columns">
+              <a class="summit-logo"
+                href="http://www.redhat.com/summit/" target="_blank"
+                rel="noopener noreferrer"><img
+                src="https://developers.redhat.com/themes/custom/rhdp/images/design/logo-summit.png"
+                alt="Red Hat Summit"></a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </footer>
+  </div>
+  <!--site-wrapper -->
+
+  <script
+    src="https://developers.redhat.com/auth/resources/3.4.3.final/login/openshift-io/js/foundation/foundation-20180411.js"
+    type="text/javascript"></script>
+  <script type="text/javascript">
+    $(document).foundation();
+</script>
+
+</body>
+</html>

--- a/dev-scripts/deploy_custom_rh-che.sh
+++ b/dev-scripts/deploy_custom_rh-che.sh
@@ -258,8 +258,9 @@ if [ "${RH_CHE_RUNNING_STANDALONE_SCRIPT}" == "true" ]; then
     exit 2
   fi
 else
-  RH_CHE_APP="./../openshift/rh-che.app.yaml"
-  RH_CHE_CONFIG="./../openshift/rh-che.config.yaml"
+  ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RH_CHE_APP="${ABSOLUTE_PATH}/../openshift/rh-che.app.yaml"
+  RH_CHE_CONFIG="${ABSOLUTE_PATH}/../openshift/rh-che.config.yaml"
 fi
 
 echo -e "\\033[92;1mGetting deployment scripts done.\\033[0m"

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -303,7 +303,10 @@ objects:
           - name: CHE_OAUTH_SERVICE__MODE
             value: "embedded"
           - name: CHE_KEYCLOAK_JS__ADAPTER__URL
-            value: "/_app/keycloak/RhCheKeycloak.js"
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-js-adapter-url
+                name: rhche
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -302,6 +302,8 @@ objects:
                 name: rhche
           - name: CHE_OAUTH_SERVICE__MODE
             value: "embedded"
+          - name: CHE_KEYCLOAK_JS__ADAPTER__URL
+            value: "/_app/keycloak/RhCheKeycloak.js"
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -37,6 +37,7 @@ data:
   che-keycloak-realm: "NULL"
   che-keycloak-client-id: "740650a2-9c44-4db5-b067-a3d1b2cd2d01"
   che-keycloak-oidc-provider: "https://auth.prod-preview.openshift.io/api"
+  che-keycloak-js-adapter-url: "/_app/keycloak/RhCheKeycloak.js"
   che-keycloak-use-nonce: "false"
   che-workspace-server-ping-success-threshold: "2"
   che-limits-user-workspaces-run-count: "1"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>6.8.0</version>
+        <version>6.7.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?

This PR adds an acceptable end-to-end registration flow for brand new users that should come into a Che Workspace from a precise Dashboard link, such as a factory link.

The additional required provisoning / setup steps are chained if necessary during the Dashboard initial user authentication.

This allows also adding some telemetry steps to identify the user into the telemtry, as well as track provisioning and dashboard start events.
New telemetry events introduced by the PR:
- `Provision User For Che`
- `Enter Che Dashboard`

The flow from a factory link looks like this for an existing RHD user that wasn't already provisioned for OSIO:

https://youtu.be/JqD6D27_nvE

Flow would be similar for a brand new RHD user (apart from the initial registration + email verification steps that are not a problem since they the factory link in the final redirection).

### What issues does this PR fix or reference?

#790 
#791 

### How have you tested this PR?

Yes, on dev cluster and through PR checks as well. 