### PR TITLE
add central snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,21 +184,16 @@
             <url>https://maven.codenvycorp.com/content/groups/public/</url>
         </repository>
         <repository>
-            <id>codenvy-public-snapshots-repo</id>
-            <name>codenvy public snapshots</name>
-            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+            <id>ossrh</id>
+            <name>central public snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>codenvy-public-repo</id>
-            <name>codenvy public</name>
-            <url>https://maven.codenvycorp.com/content/groups/public/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>codenvy-public-snapshots-repo</id>
-            <name>codenvy public snapshots</name>
-            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+            <id>ossrh</id>
+            <name>central public snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
### What does this PR do?
since upstream CHE is moved to central including snapshots we should have SN repo enabled.

Note I've removed codenvy nexus SN repo since we are not pushing artifacts to it, but still keep release repo here because rh-che project depends on old upstream version which is not on central.
So once rh-che will be switched to 6.10.0 upstream codenvy nexus releases repo maybe dropped.
