### PR TITLE
FIXUP: followup to #803 - fixing Dockerfile env variables

### DIFF
--- a/dockerfiles/functional-tests/Dockerfile
+++ b/dockerfiles/functional-tests/Dockerfile
@@ -11,30 +11,23 @@ USER root
 ENV LANG=en_US.utf8 \
     DISPLAY=:99 \
     FABRIC8_USER_NAME=fabric8
-ENV HOME=/home/$FABRIC8_USER_NAME
-ENV WORKSPACE=$HOME/che
 
 COPY google-chrome.repo /etc/yum.repos.d/google-chrome.repo
-
 RUN yum update --assumeyes && \
+    yum install --assumeyes google-chrome-stable && \
     yum install --assumeyes \
         xorg-x11-server-Xvfb \
         git \
-        maven \
-        google-crome-stable && \
+        maven && \
     yum clean all --assumeyes && \
     rm -rf /var/cache/yum && \
-    useradd --user-group --create-home --shell /bin/false ${FABRIC8_USER_NAME} && \
-    chown -R ${FABRIC8_USER_NAME}:${FABRIC8_USER_NAME} $HOME && \
-    rm -rf /home/fabric8/.pki
+    useradd --user-group --create-home --shell /bin/false ${FABRIC8_USER_NAME}
 
 USER ${FABRIC8_USER_NAME}
-WORKDIR $WORKSPACE/
+COPY docker-entrypoint.sh /home/${FABRIC8_USER_NAME}/
+WORKDIR $HOME/che/
+ENTRYPOINT ["/home/fabric8/docker-entrypoint.sh"]
 
 RUN mkdir $HOME/tmp/ && cd $HOME/tmp/ && git clone https://github.com/redhat-developer/che-functional-tests.git && \
     cd $HOME/tmp/che-functional-tests && mvn clean install -DskipTests=true && \
     cd $HOME/ && rm -rf tmp
-
-COPY docker-entrypoint.sh $HOME/
-
-ENTRYPOINT ["/home/fabric8/docker-entrypoint.sh"]

--- a/dockerfiles/functional-tests/Dockerfile
+++ b/dockerfiles/functional-tests/Dockerfile
@@ -10,9 +10,9 @@ USER root
 
 ENV LANG=en_US.utf8 \
     DISPLAY=:99 \
-    FABRIC8_USER_NAME=fabric8 \
-    HOME=/home/${FABRIC8_USER_NAME} \
-    WORKSPACE=$HOME/che
+    FABRIC8_USER_NAME=fabric8
+ENV HOME=/home/$FABRIC8_USER_NAME
+ENV WORKSPACE=$HOME/che
 
 COPY google-chrome.repo /etc/yum.repos.d/google-chrome.repo
 

--- a/dockerfiles/functional-tests/google-chrome.repo
+++ b/dockerfiles/functional-tests/google-chrome.repo
@@ -1,6 +1,6 @@
 [google-chrome]
-name=google-chrome - \$basearch
-baseurl=http://dl.google.com/linux/chrome/rpm/stable/\$basearch
+name=google-chrome
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
DO NOT MERGE! Wait for https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2214 !!  
  
### What does this PR do?
Fixing Dockerfile variables:  
`ENV` works in a very curious way.  
It supports having multiline env variable sets, but in a specific scenario:  
```
ENV var1=test \
    var2=$var1/test2
```  
the content of var2 will be set to `/test2` instead of `test/test2` because at the time when `var2` is being assigned a value, `var1` is still empty.  
Can be fixed by moving `var2` into a separate `ENV` call  

### How have you tested this PR?
manual build