### PR TITLE
rh-che Issue #727 - Enable linking github account from Che dashboard

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/redhat/che/wsmaster/deploy/Fabric8WsMasterModule.java
@@ -12,7 +12,11 @@
 package com.redhat.che.wsmaster.deploy;
 
 import com.google.inject.AbstractModule;
+import com.redhat.che.multitenant.Fabric8AuthServiceClient;
+import com.redhat.che.multitenant.Fabric8OAuthAPIProvider;
 import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.multiuser.keycloak.server.KeycloakServiceClient;
+import org.eclipse.che.multiuser.keycloak.server.deploy.OAuthAPIProvider;
 import org.eclipse.che.multiuser.keycloak.token.provider.oauth.OpenShiftGitHubOAuthAuthenticator;
 import org.eclipse.che.security.oauth.GitHubOAuthAuthenticator;
 
@@ -24,5 +28,7 @@ public class Fabric8WsMasterModule extends AbstractModule {
     bind(GitHubOAuthAuthenticator.class)
         .to(OpenShiftGitHubOAuthAuthenticator.class)
         .asEagerSingleton();
+    bind(OAuthAPIProvider.class).to(Fabric8OAuthAPIProvider.class);
+    bind(KeycloakServiceClient.class).to(Fabric8AuthServiceClient.class).asEagerSingleton();
   }
 }

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
@@ -28,3 +28,6 @@ che.fabric8.standalone=false
 
 # Option to change the HA router timeout for the route of the wsagent API endpoint 
 che.fabric8.wsagent_routing_timeout=10m
+
+# Base URL for fabric8 auth server API, e.g. "https://auth.prod-preview.openshift.io"
+che.fabric8.auth.endpoint=NULL

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -300,8 +300,6 @@ objects:
               configMapKeyRef:
                 key: analytics.woopra_domain
                 name: rhche
-          - name: CHE_OAUTH_SERVICE__MODE
-            value: "embedded"
           - name: CHE_KEYCLOAK_JS__ADAPTER__URL
             valueFrom:
               configMapKeyRef:

--- a/plugins/fabric8-multi-tenant-manager/pom.xml
+++ b/plugins/fabric8-multi-tenant-manager/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>kubernetes-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
@@ -60,12 +64,32 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-dto</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -88,12 +112,24 @@
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.infrastructure</groupId>
             <artifactId>infrastructure-kubernetes</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.infrastructure</groupId>
             <artifactId>infrastructure-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-keycloak-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-keycloak-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8AuthServiceClient.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8AuthServiceClient.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.multitenant;
+
+import com.google.common.io.CharStreams;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.jsonwebtoken.Jwt;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.multiuser.keycloak.server.KeycloakServiceClient;
+import org.eclipse.che.multiuser.keycloak.server.KeycloakSettings;
+import org.eclipse.che.multiuser.keycloak.shared.KeycloakConstants;
+import org.eclipse.che.multiuser.keycloak.shared.dto.KeycloakErrorResponse;
+
+@Singleton
+public class Fabric8AuthServiceClient extends KeycloakServiceClient {
+
+  private static final String LINKING_URL_SUFFIX = "/link";
+  private KeycloakSettings keycloakSettings;
+  private static final Gson gson =
+      new GsonBuilder()
+          .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+          .create();
+
+  @Inject
+  public Fabric8AuthServiceClient(KeycloakSettings keycloakSettings) {
+    super(keycloakSettings);
+    this.keycloakSettings = keycloakSettings;
+  }
+
+  @Override
+  public String getAccountLinkingURL(
+      @SuppressWarnings("rawtypes") Jwt token, String oauthProvider, String redirectAfterLogin) {
+    // TODO: Better way of obtaining link url
+    String linkingEndpoint =
+        UriBuilder.fromUri(keycloakSettings.get().get(KeycloakConstants.TOKEN_ENDPOINT_SETTING))
+            .path(LINKING_URL_SUFFIX)
+            .queryParam("for", "https://github.com")
+            .queryParam("redirect", redirectAfterLogin)
+            .build()
+            .toString();
+    try {
+      // TODO: require Authorization header in this request so have to do it here
+      String redirectLocationJson = doRequest(linkingEndpoint, HttpMethod.GET, null);
+      String redirectLocation =
+          gson.<Map<String, String>>fromJson(redirectLocationJson, Map.class)
+              .get("redirect_location");
+      return redirectLocation;
+    } catch (ServerException
+        | ForbiddenException
+        | NotFoundException
+        | UnauthorizedException
+        | BadRequestException
+        | IOException e) {
+      return null;
+    }
+  }
+
+  public GithubToken getGithubToken()
+      throws ServerException, ForbiddenException, NotFoundException, UnauthorizedException,
+          BadRequestException, IOException {
+    String githubEndpoint = keycloakSettings.get().get(KeycloakConstants.GITHUB_ENDPOINT_SETTING);
+    String response = doRequest(githubEndpoint, HttpMethod.GET, null);
+    return gson.fromJson(response, GithubToken.class);
+  }
+
+  // TODO Duplicated code from `KeycloakServiceClient`
+  private String doRequest(String url, String method, List<Pair<String, ?>> parameters)
+      throws IOException, ServerException, ForbiddenException, NotFoundException,
+          UnauthorizedException, BadRequestException {
+    final String authToken = EnvironmentContext.getCurrent().getSubject().getToken();
+    final boolean hasQueryParams = parameters != null && !parameters.isEmpty();
+    if (hasQueryParams) {
+      final UriBuilder ub = UriBuilder.fromUri(url);
+      for (Pair<String, ?> parameter : parameters) {
+        ub.queryParam(parameter.first, parameter.second);
+      }
+      url = ub.build().toString();
+    }
+    final HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    conn.setConnectTimeout(60000);
+    conn.setReadTimeout(60000);
+
+    try {
+      conn.setRequestMethod(method);
+      // drop a hint for server side that we want to receive application/json
+      conn.addRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+      if (authToken != null) {
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "bearer " + authToken);
+      }
+      final int responseCode = conn.getResponseCode();
+      if ((responseCode / 100) != 2) {
+        InputStream in = conn.getErrorStream();
+        if (in == null) {
+          in = conn.getInputStream();
+        }
+        final String str;
+        try (Reader reader = new InputStreamReader(in)) {
+          str = CharStreams.toString(reader);
+        }
+        final String contentType = conn.getContentType();
+        if (contentType != null
+            && (contentType.startsWith(MediaType.APPLICATION_JSON)
+                || contentType.startsWith("application/vnd.api+json"))) {
+          final KeycloakErrorResponse serviceError =
+              DtoFactory.getInstance().createDtoFromJson(str, KeycloakErrorResponse.class);
+          if (responseCode == Response.Status.FORBIDDEN.getStatusCode()) {
+            throw new ForbiddenException(serviceError.getErrorMessage());
+          } else if (responseCode == Response.Status.NOT_FOUND.getStatusCode()) {
+            throw new NotFoundException(serviceError.getErrorMessage());
+          } else if (responseCode == Response.Status.UNAUTHORIZED.getStatusCode()) {
+            throw new UnauthorizedException(serviceError.getErrorMessage());
+          } else if (responseCode == Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
+            throw new ServerException(serviceError.getErrorMessage());
+          } else if (responseCode == Response.Status.BAD_REQUEST.getStatusCode()) {
+            throw new BadRequestException(serviceError.getErrorMessage());
+          }
+          throw new ServerException(serviceError.getErrorMessage());
+        }
+        // Can't parse content as json or content has format other we expect for error.
+        throw new IOException(
+            String.format(
+                "Failed access: %s, method: %s, response code: %d, message: %s",
+                UriBuilder.fromUri(url).replaceQuery("token").build(), method, responseCode, str));
+      }
+      try (Reader reader = new InputStreamReader(conn.getInputStream())) {
+        return CharStreams.toString(reader);
+      }
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  class GithubToken {
+    private String accessToken;
+    private String providerApiUrl;
+    private String scope;
+    private String tokenType;
+    private String username;
+
+    public String getAccessToken() {
+      return accessToken;
+    }
+
+    public String getProviderApiUrl() {
+      return providerApiUrl;
+    }
+
+    public String getScope() {
+      return scope;
+    }
+
+    public String getTokenType() {
+      return tokenType;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+  }
+}

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8DelegatedOAuthAPI.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8DelegatedOAuthAPI.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.multitenant;
+
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.redhat.che.multitenant.Fabric8AuthServiceClient.GithubToken;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.multiuser.keycloak.server.oauth2.DelegatedOAuthAPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Fabric8DelegatedOAuthAPI extends DelegatedOAuthAPI {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Fabric8DelegatedOAuthAPI.class);
+  private final Fabric8AuthServiceClient authServiceClient;
+
+  @Inject
+  public Fabric8DelegatedOAuthAPI(Fabric8AuthServiceClient authServiceClient) {
+    super(authServiceClient);
+    this.authServiceClient = authServiceClient;
+  }
+
+  @Override
+  public Response authenticate(
+      UriInfo uriInfo,
+      String oauthProvider,
+      List<String> scopes,
+      String redirectAfterLogin,
+      HttpServletRequest request)
+      throws BadRequestException {
+    String accountLinkingUrl =
+        authServiceClient.getAccountLinkingURL(null, oauthProvider, redirectAfterLogin);
+    if (Strings.isNullOrEmpty(accountLinkingUrl)) {
+      LOG.error("Failed to get GitHub account linking URL");
+      return Response.status(500).build();
+    }
+    return Response.temporaryRedirect(URI.create(accountLinkingUrl)).build();
+  }
+
+  @Override
+  public OAuthToken getToken(String oauthProvider)
+      throws ForbiddenException, BadRequestException, NotFoundException, ServerException,
+          UnauthorizedException {
+    try {
+      GithubToken token = authServiceClient.getGithubToken();
+      return DtoFactory.newDto(OAuthToken.class)
+          .withToken(token.getAccessToken())
+          .withScope(token.getScope());
+    } catch (IOException e) {
+      throw new ServerException(e.getMessage());
+    }
+  }
+}

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8DelegatedOAuthAPI.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8DelegatedOAuthAPI.java
@@ -1,9 +1,10 @@
 /*
  * Copyright (c) 2016-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
@@ -30,6 +31,7 @@ import org.eclipse.che.multiuser.keycloak.server.oauth2.DelegatedOAuthAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** @author Angel Misevski (amisevsk@redhat.com) */
 public class Fabric8DelegatedOAuthAPI extends DelegatedOAuthAPI {
 
   private static final Logger LOG = LoggerFactory.getLogger(Fabric8DelegatedOAuthAPI.class);

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OAuthAPIProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OAuthAPIProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.multitenant;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.name.Named;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.multiuser.keycloak.server.deploy.OAuthAPIProvider;
+import org.eclipse.che.security.oauth.OAuthAPI;
+
+public class Fabric8OAuthAPIProvider extends OAuthAPIProvider {
+
+  private Injector injector;
+
+  @Inject
+  public Fabric8OAuthAPIProvider(
+      @Nullable @Named("che.oauth.service_mode") String oauthType, Injector injector) {
+    super(oauthType, injector);
+    this.injector = injector;
+  }
+
+  @Override
+  public OAuthAPI get() {
+    return injector.getInstance(Fabric8DelegatedOAuthAPI.class);
+  }
+}

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OAuthAPIProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OAuthAPIProvider.java
@@ -1,9 +1,10 @@
 /*
  * Copyright (c) 2016-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
@@ -17,6 +18,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.multiuser.keycloak.server.deploy.OAuthAPIProvider;
 import org.eclipse.che.security.oauth.OAuthAPI;
 
+/** @author Angel Misevski (amisevsk@redhat.com) */
 public class Fabric8OAuthAPIProvider extends OAuthAPIProvider {
 
   private Injector injector;


### PR DESCRIPTION
### What does this PR do?
Enables communication with fabric8 auth API to allow linking of github accounts from the dashboard and obtaining a github token in Che. All token management is done through fabric8 auth server, so linking a github account will link it for user's openshift.io account.

### What issues does this PR fix or reference?
#727 

### How have you tested this PR?
Manually on dev-cluster using prod-preview's auth server. Deployable image is available at `amisevsk/rhche-server:dev`.
