### PR TITLE
Added profile for running functional-tests

### DIFF
--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -23,38 +23,61 @@ verify Che itself.
 There are some jobs running periodically on clusters us-east-2, us-east-2a and free-stg as you can see in the begining of this readme.
 
 ## How to run it
-These tests require TestNG profile and listener must be set to `com.redhat.che.selenium.core.RhCheSeleniumTestHandler`. Tests expects che starter running. You can specify che starter url or use default (default value is http://localhost:10000).
-Che starter can be cloned from github: https://github.com/redhat-developer/che-starter.
+Prerequisities:
+* Working account on Openshift.io.
+* Running che-starter. Can be run as docker container like this:
+```
+docker run -p 10000:10000 -e "GITHUB_TOKEN_URL=https://auth.openshift.io/api/token?for=https://github.com" -e "OPENSHIFT_TOKEN_URL=https://sso.openshift.io/auth/realms/fabric8/broker/openshift-v3/token" -e "CHE_SERVER_URL=https://che.openshift.io" registry.devshift.net/almighty/che-starter:latest
+```
 
-To run these tests it is necessary to have some variables set:
+### Run tests via maven:
+By default, tests will execute against production environment (che.openshift.io).
+```
+mvn clean verify -Pfunctional-tests \
+    -Dche.testuser.name=<OSIO_USERNAME> \
+    -Dche.testuser.email=<OSIO_EMAIL> \
+    -Dche.testuser.offline_token=<OSIO_OFFLINE_TOKEN> \
+    -Dche.testuser.password=<OSIO_PASSWORD>
+```
+If you need to run tests against another environment (for example prod-preview), few more variables have to be set (and che-starter has to be started with different parameters). For example, running tests against `prod-preview` will look like this:
+```
+docker run -p 10000:10000 \
+    -e "GITHUB_TOKEN_URL=https://auth.prod-preview.openshift.io/api/token?for=https://github.com" \
+    -e "OPENSHIFT_TOKEN_URL=https://sso.prod-preview.openshift.io/auth/realms/fabric8/broker/openshift-v3/token" \
+    -e "CHE_SERVER_URL=https://che.prod-preview.openshift.io" \
+    registry.devshift.net/almighty/che-starter:latest
 
-VM options
+mvn clean verify -Pfunctional-tests \
+    -Dche.testuser.name=<OSIO_PROD_PREVIEW_USERNAME> \
+    -Dche.testuser.email=<OSIO_PROD_PREVIEW__EMAIL> \
+    -Dche.testuser.offline_token=<OSIO_PROD_PREVIEW__OFFLINE_TOKEN> \
+    -Dche.testuser.password=<OSIO_PROD_PREVIEW__PASSWORD> \
+    -Dche.host=che.prod-preview.openshift.io \
+    -Dche.offline.to.access.token.exchange.endpoint=https://auth.prod-preview.openshift.io/api/token/refresh
+```
 
-| Variable | Descrition |
-|----------|---------|
-| che.threads | threads in which tests will be executed |
-| che.workspace_pool_size | amount of workspace to be used while testing |
-| che.host | host where Che runs (e.g. rhche.openshift.io) |
-| che.port | port where Che runs (e.g. 443) |
-| che.protocol | protocol (https) |
-| grid.mode | false |
-| browser | browser for selenium tests (e.g. GOOGLE_CHROME) |
-| driver.port | port of driver (e.g. port of chromedriver) |
-| driver.version | version of driver |
-| excludedGroups | group of tests to be excluded |
-| cheStarterUrl | url of running che starter |
+### Full list of variables
 
-Environment variables
+These tests require TestNG profile and listener must be set to `com.redhat.che.selenium.core.RhCheSeleniumTestHandler`.
 
-| Variable | Descrition |
-|----------|---------|
-| CHE_INFRASTRUCTURE | infrastructure on which Che runs (e.g. openshift) |
-| CHE_TESTUSER_EMAIL | email of testing user |
-| CHE_TESTUSER_OFFLINE__TOKEN | refresh token of testing user |
-| CHE_MULTIUSER | use multiuser mode |
-| CHE_OFFLINE_TO_ACCESS_TOKEN_EXCHANGE_ENDPOINT | endpoint for autentization (e.g. https://auth.openshift.io/api/token/refresh) |
-| CHE_TESTUSER_NAME | username of testing user |
-| CHE_TESTUSER_PASSWORD | password of testing user |
+VM options (Mandatory parameters in __bold__)
+
+| Variable | Description | Default value|
+|----------|---------| --- |
+| __che.testuser.email__ | Openshift.io e-mail |  |
+| __che.testuser.name__ | Openshift.io username |  |
+| __che.testuser.offline_token__ | Openshift.io offline token |  |
+| __che.testuser.password__ | Openshift.io password |  |
+| che.threads | Thread count| `1` |
+| che.workspace_pool_size | Amount of workspace to be used while testing | `1` |
+| che.host | Host where Che runs | `che.openshift.io` |
+| che.port | Port where Che runs | `443` |
+| che.protocol | Protocol | `https` |
+| grid.mode | Used, when running with selenium-grid | `false` |
+| browser | browser for selenium tests | `GOOGLE_CHROME` |
+| driver.port | port of driver | `9515` |
+| excludedGroups | Group of tests to be excluded |  |
+| cheStarterUrl | URL of running che starter | `http://localhost:10000` |
 
 ## Further details
 

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -20,6 +20,18 @@
     </parent>
     <artifactId>functional-tests</artifactId>
     <properties>
+        <browser>GOOGLE_CHROME</browser>
+        <che.host>che.openshift.io</che.host>
+        <che.infrastructure>openshift</che.infrastructure>
+        <che.multiuser>true</che.multiuser>
+        <che.offline.to.access.token.exchange.endpoint>https://auth.openshift.io/api/token/refresh</che.offline.to.access.token.exchange.endpoint>
+        <che.port>443</che.port>
+        <che.protocol>https</che.protocol>
+        <che.threads>1</che.threads>
+        <che.workspace_pool_size>0</che.workspace_pool_size>
+        <cheStarterUrl>http://localhost:10000</cheStarterUrl>
+        <driver.port>9515</driver.port>
+        <grid.mode>false</grid.mode>
         <org.apache.maven.verson>3.5.2</org.apache.maven.verson>
         <skipTests>true</skipTests>
     </properties>
@@ -34,18 +46,18 @@
                 <groupId>org.eclipse.che.selenium</groupId>
                 <artifactId>che-selenium-core</artifactId>
                 <!-- <version>${che.version}</version> -->
-                <version>6.8.0</version>
+                <version>6.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.selenium</groupId>
                 <artifactId>che-selenium-test</artifactId>
                 <!-- <version>${che.version}</version> -->
-                <version>6.8.0</version>
+                <version>6.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.selenium</groupId>
                 <artifactId>che-selenium-test</artifactId>
-                <version>6.8.0</version>
+                <version>6.9.0</version>
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
@@ -119,6 +131,11 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -149,6 +166,73 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>functional-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <properties>
+                                        <property>
+                                            <name>configfailurepolicy</name>
+                                            <value>continue</value>
+                                        </property>
+                                        <property>
+                                            <name>listener</name>
+                                            <value>com.redhat.che.selenium.core.RhCheSeleniumTestHandler</value>
+                                        </property>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${project.basedir}/src/test/resources/suites/simpleTestSuite.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemPropertyVariables>
+                                <che.threads>${che.threads}</che.threads>
+                                <che.host>${che.host}</che.host>
+                                <che.workspace_pool_size>${che.workspace_pool_size}</che.workspace_pool_size>
+                                <che.port>${che.port}</che.port>
+                                <che.protocol>${che.protocol}</che.protocol>
+                                <browser>${browser}</browser>
+                                <grid.mode>${grid.mode}</grid.mode>
+                                <driver.port>${driver.port}</driver.port>
+                                <che.multiuser>${che.multiuser}</che.multiuser>
+                                <che.infrastructure>${che.infrastructure}</che.infrastructure>
+                                <che.testuser.email>${che.testuser.email}</che.testuser.email>
+                                <che.testuser.name>${che.testuser.name}</che.testuser.name>
+                                <che.testuser.offline_token>${che.testuser.offline_token}</che.testuser.offline_token>
+                                <che.testuser.password>${che.testuser.password}</che.testuser.password>
+                                <che.offline.to.access.token.exchange.endpoint>${che.offline.to.access.token.exchange.endpoint}</che.offline.to.access.token.exchange.endpoint>
+                                <excludedGroups>${excludedGroups}</excludedGroups>
+                                <cheStarterUrl>${cheStarterUrl}</cheStarterUrl>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <skipTests>false</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/CheStarterWrapper.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/CheStarterWrapper.java
@@ -39,24 +39,8 @@ public class CheStarterWrapper {
   private String cheStarterURL = "http://localhost:10000";
 
   @Inject
-  public CheStarterWrapper(
-      @Named("che.host") String cheHost, @Named("che.chromedriver.port") String chromedriverPort)
-      throws IOException, InterruptedException {
+  public CheStarterWrapper(@Named("che.host") String cheHost) {
     this.host = cheHost;
-    /* RUN CHROMEDRIVER */
-    String chromeDriverCheckCommand =
-        "lsof -i TCP | grep -q 'localhost:" + chromedriverPort + " (LISTEN)'";
-    Process chromeDriverCheck = Runtime.getRuntime().exec(chromeDriverCheckCommand);
-    chromeDriverCheck.waitFor();
-    if (chromeDriverCheck.exitValue() != 0) {
-      try {
-        Process chromedriver = Runtime.getRuntime().exec("chromedriver");
-        LOG.info("Chromedriver successfully started.");
-      } catch (IOException e) {
-        LOG.error("Could not start process chromedriver:" + e.getMessage());
-        throw e;
-      }
-    }
   }
   /** Checks whether che-starter is already running. Throws RuntimeException otherwise. */
   public void checkIsRunning() {


### PR DESCRIPTION
### What does this PR do?
* Adds possibility to run tests using maven. (profile `functional-tests`
* Updates readme accordingly
* Removes logic for starting chromedriver from code.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/331

### How have you tested this PR?
Running simpleTestSuite.xml

Note, that in order to run these tests successfully, dependency to `che-selenium-test` and `che-selenium-core` needs to be increased to 6.10.0 (to include this change: https://github.com/eclipse/che/commit/feb0065ab19310919321f223db17ccb33ac7e9a1#diff-8e00596ad8de2213ff8f8d8478d5362c)