### PR TITLE
Mechanism for using created workspace added.

### DIFF
--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
@@ -49,7 +49,6 @@ public class RhCheSeleniumSuiteModule extends AbstractModule {
   public ProvidedWorkspace getProvidedWorkspace(
       RhCheTestWorkspaceProvider workspaceProvider,
       DefaultTestUser testUser,
-      @Named("workspace.default_memory_gb") int defaultMemoryGb,
       @Named("sys.workspaceName") String givenWorkspaceName)
       throws Exception {
     ProvidedWorkspace ws = workspaceProvider.findWorkspace(testUser, givenWorkspaceName);

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
@@ -17,6 +17,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import com.google.inject.util.Providers;
 import com.redhat.che.selenium.core.client.RhCheTestWorkspaceServiceClient;
 import com.redhat.che.selenium.core.workspace.ProvidedWorkspace;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceProvider;
@@ -27,6 +29,7 @@ import org.eclipse.che.selenium.core.configuration.TestConfiguration;
 import org.eclipse.che.selenium.core.provider.DefaultTestUserProvider;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.user.MultiUserCheDefaultTestUserProvider;
+import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
 
 public class RhCheSeleniumSuiteModule extends AbstractModule {
@@ -43,14 +46,35 @@ public class RhCheSeleniumSuiteModule extends AbstractModule {
             .build(TestWorkspaceServiceClientFactory.class));
     bind(TestWorkspaceServiceClient.class).to(RhCheTestWorkspaceServiceClient.class);
     bind(TestWorkspaceProvider.class).to(RhCheTestWorkspaceProvider.class).asEagerSingleton();
+    if (config.getMap().get("che.workspaceName") == null) {
+      bind(String.class)
+          .annotatedWith(Names.named("che.workspaceName"))
+          .toProvider(Providers.<String>of(null));
+    }
+  }
+
+  @Provides
+  public TestWorkspace getWorkspace(
+      TestWorkspaceProvider workspaceProvider,
+      DefaultTestUser testUser,
+      @Named("workspace.default_memory_gb") int defaultMemoryGb)
+      throws Exception {
+    TestWorkspace ws =
+        workspaceProvider.createWorkspace(testUser, defaultMemoryGb, "default.json", true);
+    ws.await();
+    return ws;
   }
 
   @Provides
   public ProvidedWorkspace getProvidedWorkspace(
       RhCheTestWorkspaceProvider workspaceProvider,
       DefaultTestUser testUser,
-      @Named("sys.workspaceName") String givenWorkspaceName)
+      @Named("che.workspaceName") String givenWorkspaceName)
       throws Exception {
+    if (givenWorkspaceName == null) {
+      throw new RuntimeException(
+          "Variable `che.workspaceName` must be set to use ProvidedWorkspace");
+    }
     ProvidedWorkspace ws = workspaceProvider.findWorkspace(testUser, givenWorkspaceName);
     ws.await();
     return ws;

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
@@ -14,8 +14,11 @@ package com.redhat.che.selenium.core;
 import static com.google.inject.name.Names.named;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Named;
 import com.redhat.che.selenium.core.client.RhCheTestWorkspaceServiceClient;
+import com.redhat.che.selenium.core.workspace.ProvidedWorkspace;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceProvider;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClientFactory;
@@ -40,5 +43,17 @@ public class RhCheSeleniumSuiteModule extends AbstractModule {
             .build(TestWorkspaceServiceClientFactory.class));
     bind(TestWorkspaceServiceClient.class).to(RhCheTestWorkspaceServiceClient.class);
     bind(TestWorkspaceProvider.class).to(RhCheTestWorkspaceProvider.class).asEagerSingleton();
+  }
+
+  @Provides
+  public ProvidedWorkspace getProvidedWorkspace(
+      RhCheTestWorkspaceProvider workspaceProvider,
+      DefaultTestUser testUser,
+      @Named("workspace.default_memory_gb") int defaultMemoryGb,
+      @Named("sys.workspaceName") String givenWorkspaceName)
+      throws Exception {
+    ProvidedWorkspace ws = workspaceProvider.findWorkspace(testUser, givenWorkspaceName);
+    ws.await();
+    return ws;
   }
 }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
@@ -103,7 +103,6 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
       waitStatus(workspaceName, owner.getName(), WorkspaceStatus.RUNNING);
       LOG.info("Workspace " + workspaceName + "is running.");
     } catch (Exception e) {
-
       LOG.error("Failed to start workspace \"" + workspaceName + "\": " + e.getMessage(), e);
       throw e;
     }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
@@ -94,6 +94,10 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
   @Override
   public void start(String workspaceId, String workspaceName, TestUser workspaceOwner)
       throws Exception {
+    if (getStatus(workspaceId).equals(WorkspaceStatus.RUNNING)) {
+      LOG.info("Workspace is running - no need to start it.");
+      return;
+    }
     try {
       this.cheStarterWrapper.startWorkspace(workspaceId, workspaceName, token);
       waitStatus(workspaceName, owner.getName(), WorkspaceStatus.RUNNING);

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
@@ -15,6 +15,13 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import com.redhat.che.selenium.core.workspace.CheStarterWrapper;
+import java.io.IOException;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
@@ -112,5 +119,17 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
       LOG.error("Failed to delete workspace \"" + workspaceName + "\": " + e.getMessage(), e);
       throw e;
     }
+  }
+
+  public Workspace findExistingWorkspace(String workspaceName)
+      throws ServerException, UnauthorizedException, ForbiddenException, NotFoundException,
+          ConflictException, BadRequestException, IOException {
+    if (owner == null) {
+      throw new IllegalStateException("Workspace does not have an owner.");
+    }
+    return requestFactory
+        .fromUrl(getNameBasedUrl(workspaceName, owner.getName()))
+        .request()
+        .asDto(WorkspaceDto.class);
   }
 }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/ProvidedWorkspace.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/ProvidedWorkspace.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.selenium.core.workspace;
+
+import static java.lang.String.format;
+
+import com.redhat.che.selenium.core.client.RhCheTestWorkspaceServiceClient;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.selenium.core.user.TestUser;
+import org.eclipse.che.selenium.core.workspace.TestWorkspace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+/** @author Anatolii Bazko */
+public class ProvidedWorkspace implements TestWorkspace {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProvidedWorkspace.class);
+
+  private CompletableFuture<Void> future;
+  private AtomicReference<String> id;
+  private AtomicReference<String> workspaceName;
+  private AtomicReference<TestUser> owner;
+  private RhCheTestWorkspaceServiceClient workspaceServiceClient;
+  private String givenWorksapceName;
+
+  public ProvidedWorkspace(
+      TestUser owner,
+      RhCheTestWorkspaceServiceClient testWorkspaceServiceClient,
+      String givenWorkspaceName) {
+    this.id = new AtomicReference<>();
+    this.workspaceName = new AtomicReference<>();
+    this.owner = new AtomicReference<>();
+    this.owner.set(owner);
+    this.workspaceServiceClient = testWorkspaceServiceClient;
+    this.givenWorksapceName = givenWorkspaceName;
+    if (this.workspaceServiceClient == null) {
+      throw new IllegalArgumentException(
+          "workspaceServiceClient is null. Probably AbstractTestWorkspaceServiceClient is not instance of RhChe...");
+    }
+
+    this.future =
+        CompletableFuture.runAsync(
+            () -> {
+              try {
+                final Workspace ws =
+                    workspaceServiceClient.findExistingWorkspace(givenWorkspaceName);
+                this.id.set(ws.getId());
+                this.workspaceName.set(ws.getConfig().getName());
+                long start = System.currentTimeMillis();
+                workspaceServiceClient.start(
+                    this.id.get(), this.workspaceName.get(), this.owner.get());
+                LOG.info(
+                    "Workspace name='{}' id='{}' started in {} sec.",
+                    workspaceName.get(),
+                    ws.getId(),
+                    (System.currentTimeMillis() - start) / 1000);
+              } catch (Exception e) {
+                String errorMessage =
+                    format("Workspace name='%s' start failed.", this.workspaceName.get());
+                LOG.error(errorMessage, e);
+
+                try {
+                  workspaceServiceClient.delete(
+                      this.workspaceName.get(), this.owner.get().getName());
+                } catch (Exception e1) {
+                  LOG.error(
+                      "Failed to remove workspace name='{}' when start is failed.",
+                      this.workspaceName.get());
+                }
+
+                if (e instanceof IllegalStateException) {
+                  Assert.fail("Known issue https://github.com/eclipse/che/issues/8856", e);
+                } else {
+                  throw new IllegalStateException(errorMessage, e);
+                }
+              }
+            });
+  }
+
+  @Override
+  public void await() throws InterruptedException, ExecutionException {
+    this.future.get();
+  }
+
+  @Override
+  public String getName() throws ExecutionException, InterruptedException {
+    return this.future.thenApply(aVoid -> this.workspaceName.get()).get();
+  }
+
+  @Override
+  public String getId() throws ExecutionException, InterruptedException {
+    return this.future.thenApply(aVoid -> this.id.get()).get();
+  }
+
+  @Override
+  public TestUser getOwner() {
+    return this.owner.get();
+  }
+
+  @Override
+  public void delete() {
+    // the provided workspace should not be deleted
+  }
+}

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/ProvidedWorkspace.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/ProvidedWorkspace.java
@@ -34,7 +34,6 @@ public class ProvidedWorkspace implements TestWorkspace {
   private AtomicReference<String> workspaceName;
   private AtomicReference<TestUser> owner;
   private RhCheTestWorkspaceServiceClient workspaceServiceClient;
-  private String givenWorksapceName;
 
   public ProvidedWorkspace(
       TestUser owner,
@@ -45,7 +44,6 @@ public class ProvidedWorkspace implements TestWorkspace {
     this.owner = new AtomicReference<>();
     this.owner.set(owner);
     this.workspaceServiceClient = testWorkspaceServiceClient;
-    this.givenWorksapceName = givenWorkspaceName;
     if (this.workspaceServiceClient == null) {
       throw new IllegalArgumentException(
           "workspaceServiceClient is null. Probably AbstractTestWorkspaceServiceClient is not instance of RhChe...");
@@ -71,15 +69,6 @@ public class ProvidedWorkspace implements TestWorkspace {
                 String errorMessage =
                     format("Workspace name='%s' start failed.", this.workspaceName.get());
                 LOG.error(errorMessage, e);
-
-                try {
-                  workspaceServiceClient.delete(
-                      this.workspaceName.get(), this.owner.get().getName());
-                } catch (Exception e1) {
-                  LOG.error(
-                      "Failed to remove workspace name='{}' when start is failed.",
-                      this.workspaceName.get());
-                }
 
                 if (e instanceof IllegalStateException) {
                   Assert.fail("Known issue https://github.com/eclipse/che/issues/8856", e);

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
@@ -65,6 +65,16 @@ public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
             : null);
   }
 
+  public ProvidedWorkspace findWorkspace(TestUser owner, String name) {
+    this.cheStarterWrapper.checkIsRunning();
+    return new ProvidedWorkspace(
+        owner,
+        testWorkspaceServiceClient instanceof RhCheTestWorkspaceServiceClient
+            ? (RhCheTestWorkspaceServiceClient) testWorkspaceServiceClient
+            : null,
+        name);
+  }
+
   @Override
   protected void initializePool() {
     LOG.info("Initialize workspace pool with {} entries.", poolSize);

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceProvider.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
-import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClientFactory;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.user.TestUser;
@@ -32,6 +31,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
 
   private CheStarterWrapper cheStarterWrapper;
+  private final RhCheTestWorkspaceServiceClient rhcheWorksapceClient;
 
   @Inject
   protected RhCheTestWorkspaceProvider(
@@ -40,7 +40,7 @@ public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
       @Named("workspace.default_memory_gb") int defaultMemoryGb,
       DefaultTestUser defaultUser,
       WorkspaceDtoDeserializer workspaceDtoDeserializer,
-      TestWorkspaceServiceClient testWorkspaceServiceClient,
+      RhCheTestWorkspaceServiceClient testWorkspaceServiceClient,
       TestWorkspaceServiceClientFactory testWorkspaceServiceClientFactory,
       CheStarterWrapper cheStarterWrapper) {
     super(
@@ -52,27 +52,19 @@ public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
         testWorkspaceServiceClient,
         testWorkspaceServiceClientFactory);
     this.cheStarterWrapper = cheStarterWrapper;
+    this.rhcheWorksapceClient = testWorkspaceServiceClient;
   }
 
   @Override
   public TestWorkspace createWorkspace(
       TestUser owner, int memoryGB, String template, boolean startAfterCreation) {
     this.cheStarterWrapper.checkIsRunning();
-    return new RhCheTestWorkspaceImpl(
-        owner,
-        testWorkspaceServiceClient instanceof RhCheTestWorkspaceServiceClient
-            ? (RhCheTestWorkspaceServiceClient) testWorkspaceServiceClient
-            : null);
+    return new RhCheTestWorkspaceImpl(owner, rhcheWorksapceClient);
   }
 
   public ProvidedWorkspace findWorkspace(TestUser owner, String name) {
     this.cheStarterWrapper.checkIsRunning();
-    return new ProvidedWorkspace(
-        owner,
-        testWorkspaceServiceClient instanceof RhCheTestWorkspaceServiceClient
-            ? (RhCheTestWorkspaceServiceClient) testWorkspaceServiceClient
-            : null,
-        name);
+    return new ProvidedWorkspace(owner, rhcheWorksapceClient, name);
   }
 
   @Override
@@ -93,12 +85,7 @@ public class RhCheTestWorkspaceProvider extends AbstractTestWorkspaceProvider {
             String name = generateName();
             TestWorkspace testWorkspace;
             try {
-              testWorkspace =
-                  new RhCheTestWorkspaceImpl(
-                      defaultUser,
-                      testWorkspaceServiceClient instanceof RhCheTestWorkspaceServiceClient
-                          ? (RhCheTestWorkspaceServiceClient) testWorkspaceServiceClient
-                          : null);
+              testWorkspace = new RhCheTestWorkspaceImpl(defaultUser, rhcheWorksapceClient);
             } catch (Exception e) {
               // scheduled executor service doesn't log any exceptions, so log possible exception
               // here

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/EETest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/EETest.java
@@ -14,19 +14,29 @@ package com.redhat.che.functional.tests;
 import com.google.inject.Inject;
 import com.redhat.che.selenium.core.workspace.ProvidedWorkspace;
 import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 // class for trying ProvidedWorkspace functionality
 public class EETest {
 
-  @Inject private ProvidedWorkspace worksapce;
+  @Inject private ProvidedWorkspace workspace;
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestTestClass.class);
 
   @Test
   public void mytest() {
     try {
-      worksapce.getName();
+      LOG.info(
+          "Workspace with name: "
+              + workspace.getName()
+              + " and id: "
+              + workspace.getId()
+              + " was successfully injected. ");
     } catch (ExecutionException | InterruptedException e) {
-      // TODO Auto-generated catch block
+      LOG.error(
+          "Could not obtain workspace name and id - worskape was probably not successfully injected.");
       e.printStackTrace();
     }
     System.out.println("Test with provided workspace has passed.");

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/EETest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/EETest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.functional.tests;
+
+import com.google.inject.Inject;
+import com.redhat.che.selenium.core.workspace.ProvidedWorkspace;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+
+// class for trying ProvidedWorkspace functionality
+public class EETest {
+
+  @Inject private ProvidedWorkspace worksapce;
+
+  @Test
+  public void mytest() {
+    try {
+      worksapce.getName();
+    } catch (ExecutionException | InterruptedException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    System.out.println("Test with provided workspace has passed.");
+  }
+}


### PR DESCRIPTION
### What does this PR do?
In upstream tests, the possibility of using workspace which was created outside tests was missing. New workspace class ProvidedWorkspace as created and new methods to provide it were added. 

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/343

### How have you tested this PR?
Locally against production. 
