### PR TITLE
Wrong noVNC port fixed.

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -173,7 +173,7 @@
               ],
               "servers": {
                 "VNC" : {
-                  "port" : "6091",
+                  "port" : "6901",
                   "protocol" : "http"
                 }
               },


### PR DESCRIPTION
noVNC port should be 6901 according to
eclipse/che-dockerfiles/blob/master/recipes/android/Dockerfile#L15

Upstream fix: https://github.com/eclipse/che/pull/11033

Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?


### What issues does this PR fix or reference?


### How have you tested this PR?
