### PR TITLE
Adding/changing server names to be in sync with upstream samples.

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -253,7 +253,12 @@
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
-              "servers": {},
+              "servers": {
+                "tomcat8" : {
+                  "port" : "8080",
+                  "protocol" : "http"
+                }
+              },
               "attributes": {
                 "memoryLimitBytes": "2147483648"
               }
@@ -374,7 +379,7 @@
                 "com.redhat.oc-login"
               ],
               "servers": {
-                "5000/tcp" : {
+                "dotnet" : {
                   "port" : "5000",
                   "protocol" : "http"
                 }
@@ -408,7 +413,7 @@
           "type": "custom",
           "commandLine": "cd ${current.project.path} && dotnet run",
           "attributes": {
-            "previewUrl": "${server.5000/tcp}",
+            "previewUrl": "${dotnet}",
             "goal": "Run"
           }
         }
@@ -827,6 +832,18 @@
               "servers": {
                 "8080/tcp" : {
                   "port" : "8080",
+                  "protocol" : "http"
+                },
+                "3000/tcp" : {
+                  "port" : "3000",
+                  "protocol" : "http"
+                },
+                "5000/tcp" : {
+                  "port" : "5000",
+                  "protocol" : "http"
+                },
+                "9000/tcp" : {
+                  "port" : "9000",
                   "protocol" : "http"
                 }
               }


### PR DESCRIPTION
Issue #820

Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Adds servers to `java-default` and `Node.js` stacks and changes the server names of `dotnet` stacks to be in sync with sample projects.

### What issues does this PR fix or reference?
#820

### How have you tested this PR?
