### PR TITLE
Add capability to share workspace by factory

### DIFF
--- a/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.controller.ts
+++ b/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.controller.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+import { CheAPI } from '../../../components/api/che-api.factory';
+import { CheNotification } from '../../../components/notification/che-notification.factory';
+import { CheWorkspace } from '../../../components/api/workspace/che-workspace.factory';
+
+/**
+ * Controller for workspace sharing with other users via factories
+ *
+ * @ngdoc controller
+ * @name workspace.details.controller:ShareWorkspaceController
+ * @description Controller for sharing workspaces via factory
+ * @author Angel Misevski
+ */
+export class ShareWorkspaceController {
+
+  static $inject = ['cheWorkspace', 'cheAPI', 'cheNotification', '$location', '$route', '$log'];
+
+  /** Interaction with server API */
+  private cheAPI: CheAPI;
+  /** Che notification service */
+  private cheNotification: CheNotification;
+  /** JSON representing the current workspace */
+  private workspace: che.IWorkspace;
+
+  private $location: ng.ILocationService;
+  private $log: ng.ILogService;
+
+  private form: ng.IFormController;
+  private factoryName: string;
+  private isLoading: boolean;
+
+  constructor(cheWorkspace: CheWorkspace,
+              cheAPI: CheAPI,
+              cheNotification: CheNotification,
+              $location: ng.ILocationService,
+              $route: ng.route.IRouteService,
+              $log: ng.ILogService) {
+    this.cheAPI = cheAPI;
+
+    this.cheNotification = cheNotification;
+    this.$location = $location;
+    this.$log = $log;
+
+    // Use route to get workspace json
+    let namespace: string = $route.current.params.namespace;
+    let workspaceName: string = $route.current.params.workspaceName;
+
+    this.workspace = cheWorkspace.getWorkspaceByName(namespace, workspaceName);
+
+    this.isLoading = false;
+    this.factoryName = ''
+  }
+
+  createFactoryForWorkspace() {
+    this.isLoading = true;
+    let factoryContentPromise: ng.IPromise = this.cheAPI.getFactory().fetchFactoryContentFromWorkspace(this.workspace);
+    factoryContentPromise.then((factoryContent: any) => {
+
+      if (this.factoryName) {
+        // try to set factory name
+        try {
+          let factoryObject = angular.fromJson(factoryContent);
+          factoryObject.name = this.factoryName;
+          factoryContent = angular.toJson(factoryObject);
+        } catch (e) {
+          this.$log.error(e);
+        }
+      }
+      let factoryPromise: ng.IPromise = this.cheAPI.getFactory().createFactoryByContent(factoryContent)
+
+      factoryPromise.then((factory: any) => {
+        this.isLoading = false;
+        this.$location.path('/factory/' + factory.id);
+      }, (error: any) => {
+        this.isLoading = false;
+        this.cheNotification.showError(error.data.message ? error.data.message : 'Failed to create Factory.');
+      });
+
+    }, (error: any) => {
+
+      let message = (error.data && error.data.message) ? error.data.message : 'Get factory configuration failed.';
+      if (error.status === 400) {
+        message = 'Factory can\'t be created. The selected workspace has no projects defined. Project sources must be available from an external storage.';
+      }
+
+      this.isLoading = false;
+      this.cheNotification.showError(message);
+    });
+  }
+
+  setForm(form: any): void {
+    this.form = form;
+  }
+
+  isFormInvalid(): boolean {
+    return this.form ? this.form.$invalid : false;
+  }
+}

--- a/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.html
+++ b/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.html
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (c) 2016-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<che-description che-link-title="Learn more about Che factories." che-link="/docs/factories.html">
+  Workspace sharing is currently only supported via factories.
+</che-description>
+<md-content md-scroll-y flex layout="column" md-theme="maincontent-theme">
+  <md-progress-linear md-mode="indeterminate"
+                      class="create-factory-progress"
+                      ng-show="shareWorkspaceController.isLoading"></md-progress-linear>
+  <!-- Factory name input box -->
+  <che-label-container che-label-name="Factory Name"
+                       che-label-description="Define a name for your Factory.">
+    <ng-form name="factoryNameForm">
+      <che-input-box ng-init="shareWorkspaceController.setForm(factoryNameForm)"
+                     che-form="factoryNameForm"
+                     che-name="name"
+                     che-place-holder="Name of the factory"
+                     aria-label="Name of the factory"
+                     ng-model="shareWorkspaceController.factoryName"
+                     ng-trim
+                     ng-minlength="3"
+                     ng-maxlength="20"
+                     ng-pattern="/^[ A-Za-z0-9_\-\.]+$/"
+                     id="new-factory-name-input"
+                     unique-factory-name="">
+        <div ng-message="pattern">Factory name may contain digits, latin letters, spaces, _ , . , - and should start only with digits, latin letters or underscores</div>
+        <div ng-message="minlength">The name has to be more than 3 characters long.</div>
+        <div ng-message="maxlength">The name has to be less than 20 characters long.</div>
+        <div ng-message="uniqueFactoryName">This factory name is already used.</div>
+      </che-input-box>
+    </ng-form>
+  </che-label-container>
+  <!-- Create Factory button -->
+  <che-label-container>
+    <che-button-save-flat id="share-workspace-as-factory-button"
+                          che-button-title="Create Factory"
+                          ng-click="shareWorkspaceController.createFactoryForWorkspace()"
+                          ng-disabled="shareWorkspaceController.isFormInvalid()"></che-button-save-flat>
+  </che-label-container>
+</md-content>

--- a/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.styl
+++ b/assembly/fabric8-ide-dashboard-war/src/app/workspaces/share-workspace/share-workspace.styl
@@ -1,0 +1,34 @@
+md-content .workspace-create-factory
+  overflow auto
+  min-height calc(100vh - 152px)
+  background-color $white-color !important
+  padding 0 14px
+  .che-label-container-label
+    min-width 160px
+    width 160px
+
+  .che-input-box
+    padding 25px
+    border-bottom 1px solid $list-separator-color
+
+    div.che-label-container-label, div.che-input-box-desktop-label
+      min-width 160px
+      width 160px
+
+  button
+    margin-left 0
+    margin-right 0
+    margin-bottom 16px
+
+  .che-label-container-content .create-factory-input
+    margin -6px 0
+
+che-button-save-flat#share-workspace-as-factory-button button
+  margin 10px 0 100px
+  width 100% !important
+
+md-progress-linear.create-factory-progress
+  z-index 1
+  height 10px
+  position absolute
+


### PR DESCRIPTION
### What does this PR do?
Replace the share tab on a workspace page with a page explaining that sharing is only available via factories at the moment, and give the user an option to create a factory for the current workspace from within the page.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/798 (via discussion in housekeeping issue around current workspace sharing issues)

### How have you tested this PR?
Locally and on dev cluster.

![share-workspace-2](https://user-images.githubusercontent.com/16168279/45333532-b4c4cc80-b544-11e8-8d47-6a0e7ae0e734.gif)
