### PR TITLE
Improvements to minishift addon yaml template

### DIFF
--- a/openshift/minishift-addons/rhche-prerequisites/rhche-prerequisites.addon
+++ b/openshift/minishift-addons/rhche-prerequisites/rhche-prerequisites.addon
@@ -2,7 +2,7 @@
 # Description: Setup and Configure Prerequisites to run Eclipse Che (rh-che distribution)
 # Url: https://github.com/redhat-developer/rh-che
 # Required-Vars: NAMESPACE, KEYCLOAK_DOCKER_IMAGE, RH_CHE_VERSION, KEYCLOAK_CONFIGURATOR_DOCKER_IMAGE
-# Var-Defaults: NAMESPACE=rhche, KEYCLOAK_DOCKER_IMAGE=eclipse/che-keycloak, RH_CHE_VERSION=latest, KEYCLOAK_CONFIGURATOR_DOCKER_IMAGE=registry.devshift.net/che/rh-che-standalone-keycloak-configurator
+# Var-Defaults: NAMESPACE=rhche, KEYCLOAK_DOCKER_IMAGE=eclipse/che-keycloak, RH_CHE_VERSION=latest, KEYCLOAK_CONFIGURATOR_DOCKER_IMAGE=quay.io/openshiftio/che-rh-che-standalone-keycloak-configurator
 # OpenShift-Version: >=3.5.0
 
 echo [CHE] Creating #{NAMESPACE} project as developer

--- a/openshift/minishift-addons/rhche-prerequisites/templates/keycloak-template.yaml
+++ b/openshift/minishift-addons/rhche-prerequisites/templates/keycloak-template.yaml
@@ -215,12 +215,11 @@ parameters:
 - name: KEYCLOAK_CONFIGURATOR_DOCKER_IMAGE
   displayName: Keycloak configurator image
   description: Keycloak configurator image for RhChe standalone
-  value: registry.devshift.net/che/rh-che-standalone-keycloak-configurator
+  value: quay.io/openshiftio/che-rh-che-standalone-keycloak-configurator
 - name: RH_CHE_VERSION
   displayName: RhChe version
   description: RhChe version which defaults to latest
   value: latest
-      
 labels:
   app: keycloak
   template: keycloak

--- a/openshift/minishift-addons/rhche/rhche.addon
+++ b/openshift/minishift-addons/rhche/rhche.addon
@@ -2,7 +2,7 @@
 # Description: Setup and Configure Eclipse Che (rh-che distribution)
 # Url: https://github.com/redhat-developer/rh-che
 # Required-Vars: NAMESPACE, RH_CHE_DOCKER_IMAGE, RH_CHE_VERSION, KEYCLOAK_DOCKER_IMAGE
-# Var-Defaults: NAMESPACE=rhche, RH_CHE_DOCKER_IMAGE=registry.devshift.net/che/rh-che-server, RH_CHE_VERSION=latest, KEYCLOAK_DOCKER_IMAGE=eclipse/che-keycloak
+# Var-Defaults: NAMESPACE=rhche, RH_CHE_DOCKER_IMAGE=quay.io/openshiftio/che-rh-che-server, RH_CHE_VERSION=latest, KEYCLOAK_DOCKER_IMAGE=eclipse/che-keycloak
 # OpenShift-Version: >=3.5.0
 
 echo [CHE] Create the Che server Template

--- a/openshift/minishift-addons/rhche/rhche.addon.remove
+++ b/openshift/minishift-addons/rhche/rhche.addon.remove
@@ -6,6 +6,8 @@
 
 echo [CHE] Deleting all Che objects (deploymentconfig, services, routes etc...)
 oc delete all -l app=rhche -n #{NAMESPACE}
+oc delete rolebinding rhche -n #{NAMESPACE}
+oc delete serviceaccount rhche -n #{NAMESPACE}
 
 echo [CHE] Removing Che server Template
 oc delete -f templates/rh-che.app.yaml -n openshift

--- a/openshift/minishift-addons/rhche/templates/rh-che.app.yaml
+++ b/openshift/minishift-addons/rhche/templates/rh-che.app.yaml
@@ -75,34 +75,28 @@ objects:
       spec:
         containers:
         - env:
-          - name: OPENSHIFT_KUBE_PING_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: CHE_MULTIUSER
-            valueFrom:
-              configMapKeyRef:
-                key: multi-user
-                name: rhche
-          - name: CHE_HOST
-            value: "rhche-${NAMESPACE}.${ROUTING_SUFFIX}"
-          - name: CHE_PORT
-            value: "8080"
           - name: CHE_API
             value: "${PROTOCOL}://rhche-${NAMESPACE}.${ROUTING_SUFFIX}/api"
-          - name: CHE_WEBSOCKET_ENDPOINT
-            value: "${WS_PROTOCOL}://rhche-${NAMESPACE}.${ROUTING_SUFFIX}/api/websocket"
           - name: CHE_DEBUG_SERVER
             valueFrom:
               configMapKeyRef:
                 key: remote-debugging-enabled
                 name: rhche
-          - name: CHE_INFRASTRUCTURE_ACTIVE
-            value: "openshift"
+          - name: CHE_FABRIC8_AUTH_ENDPOINT
+            value: ${CHE_FABRIC8_AUTH_ENDPOINT}
+          - name: CHE_FABRIC8_MULTICLUSTER_OSO_PROXY_URL
+            value: ${CHE_FABRIC8_MULTICLUSTER_OSO_PROXY_URL}
+          - name: CHE_FABRIC8_MULTITENANT
+            valueFrom:
+              configMapKeyRef:
+                key: che-fabric8-multitenant
+                name: rhche
+          - name: CHE_FABRIC8_STANDALONE
+            value: "true"
+          - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
+            value: ${CHE_FABRIC8_USER__SERVICE_ENDPOINT}
+          - name: CHE_HOST
+            value: "rhche-${NAMESPACE}.${ROUTING_SUFFIX}"
           - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
             value: "${PROTOCOL}://rhche-${NAMESPACE}.${ROUTING_SUFFIX}/agent-binaries/linux_amd64/bootstrapper/bootstrapper"
           - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
@@ -110,86 +104,105 @@ objects:
               configMapKeyRef:
                 key: infra-machine-start-timeout
                 name: rhche
-          - name: CHE_INFRA_OPENSHIFT_PROJECT
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
-            valueFrom:
-              configMapKeyRef:
-                key: infra-pvc-strategy
-                name: rhche
           - name: CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS
             valueFrom:
               configMapKeyRef:
                 key: che-openshift-precreate-subpaths
                 name: rhche
-          - name: CHE_INFRA_OPENSHIFT_TLS__ENABLED
+          - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
             valueFrom:
               configMapKeyRef:
-                key: che-openshift-secure-routes
+                key: infra-pvc-strategy
                 name: rhche
           - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
             valueFrom:
               configMapKeyRef:
                 key: infra-trust-certs
                 name: rhche
-          - name: CHE_LOCAL_CONF_DIR
+          - name: CHE_INFRA_OPENSHIFT_PROJECT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CHE_INFRA_OPENSHIFT_TLS__ENABLED
             valueFrom:
               configMapKeyRef:
-                key: local-conf-dir
+                key: che-openshift-secure-routes
                 name: rhche
-          - name: CHE_LOGS_DIR
-            valueFrom:
-              configMapKeyRef:
-                key: che.logs.dir
-                name: rhche
-          - name: CHE_LOG_LEVEL
-            valueFrom:
-              configMapKeyRef:
-                key: log-level
-                name: rhche
+          - name: CHE_INFRASTRUCTURE_ACTIVE
+            value: "openshift"
           - name: CHE_KEYCLOAK_AUTH__SERVER__URL
             value: "${CHE_KEYCLOAK_AUTH__SERVER__URL}"
-          - name: JAVA_OPTS
-            valueFrom:
-              configMapKeyRef:
-                key: che-server-java-opts
-                name: rhche
-          - name: CHE_WORKSPACE_AUTO__START
-            valueFrom:
-              configMapKeyRef:
-                key: enable-workspaces-autostart
-                name: rhche
           - name: CHE_KEYCLOAK_CLIENT__ID
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-client-id
                 name: rhche
+          - name: CHE_KEYCLOAK_GITHUB_ENDPOINT
+            value: ${CHE_KEYCLOAK_AUTH__SERVER__URL}/realms/che/broker/github/token
           - name: CHE_KEYCLOAK_OIDC__PROVIDER
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-oidc-provider
+                name: rhche
+          - name: CHE_KEYCLOAK_REALM
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-realm
                 name: rhche
           - name: CHE_KEYCLOAK_USE__NONCE
             valueFrom:
               configMapKeyRef:
                 key: che-keycloak-use-nonce
                 name: rhche
-          - name: CHE_WORKSPACE_STORAGE
+          - name: CHE_LIMITS_USER_WORKSPACES_RUN_COUNT
             valueFrom:
               configMapKeyRef:
-                key: workspace-storage
-                name: rhche
-          - name: CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS
-            valueFrom:
-              configMapKeyRef:
-                key: che.workspace.agent.dev.inactive_stop_timeout_ms
+                key: che-limits-user-workspaces-run-count
                 name: rhche
           - name: CHE_LIMITS_WORKSPACE_ENV_RAM
             valueFrom:
               configMapKeyRef:
                 key: workspaces-memory-limit-max
+                name: rhche
+          - name: CHE_LOCAL_CONF_DIR
+            valueFrom:
+              configMapKeyRef:
+                key: local-conf-dir
+                name: rhche
+          - name: CHE_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                key: log-level
+                name: rhche
+          - name: CHE_LOGS_DIR
+            valueFrom:
+              configMapKeyRef:
+                key: che.logs.dir
+                name: rhche
+          - name: CHE_MULTIUSER
+            valueFrom:
+              configMapKeyRef:
+                key: multi-user
+                name: rhche
+          - name: CHE_OAUTH_SERVICE__MODE
+            value: "embedded"
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
+            value: NULL
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
+            value: NULL
+          - name: CHE_PORT
+            value: "8080"
+          - name: CHE_WEBSOCKET_ENDPOINT
+            value: "${WS_PROTOCOL}://rhche-${NAMESPACE}.${ROUTING_SUFFIX}/api/websocket"
+          - name: CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS
+            valueFrom:
+              configMapKeyRef:
+                key: che.workspace.agent.dev.inactive_stop_timeout_ms
+                name: rhche
+          - name: CHE_WORKSPACE_AUTO__START
+            valueFrom:
+              configMapKeyRef:
+                key: enable-workspaces-autostart
                 name: rhche
           - name: CHE_WORKSPACE_DEFAULT__MEMORY__MB
             valueFrom:
@@ -201,51 +214,39 @@ objects:
               configMapKeyRef:
                 key: che-workspaces-java-opts
                 name: rhche
-          - name: CHE_KEYCLOAK_GITHUB_ENDPOINT
-            value: ${CHE_KEYCLOAK_AUTH__SERVER__URL}/realms/che/broker/github/token
-          - name: CHE_FABRIC8_MULTITENANT
-            valueFrom:
-              configMapKeyRef:
-                key: che-fabric8-multitenant
-                name: rhche
-          - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
-            value: ${CHE_FABRIC8_USER__SERVICE_ENDPOINT}
-          - name: CHE_FABRIC8_AUTH_ENDPOINT
-            value: ${CHE_FABRIC8_AUTH_ENDPOINT}
-          - name: CHE_FABRIC8_MULTICLUSTER_OSO_PROXY_URL
-            value: ${CHE_FABRIC8_MULTICLUSTER_OSO_PROXY_URL}
           - name: CHE_WORKSPACE_LOGS_ROOT__DIR
             valueFrom:
               configMapKeyRef:
                 key: che-workspace-logs
                 name: rhche
-          - name: CHE_KEYCLOAK_REALM
-            valueFrom:
-              configMapKeyRef:
-                key: che-keycloak-realm
-                name: rhche
-          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
-            value: NULL
-          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
-            value: NULL
           - name: CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD
             valueFrom:
               configMapKeyRef:
                 key: che-workspace-server-ping-success-threshold
                 name: rhche
-          - name: CHE_LIMITS_USER_WORKSPACES_RUN_COUNT
+          - name: CHE_WORKSPACE_STORAGE
             valueFrom:
               configMapKeyRef:
-                key: che-limits-user-workspaces-run-count
+                key: workspace-storage
                 name: rhche
+
+          - name: JAVA_OPTS
+            valueFrom:
+              configMapKeyRef:
+                key: che-server-java-opts
+                name: rhche
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPENSHIFT_KUBE_PING_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: PROTOCOL
             value: "${PROTOCOL}"
           - name: ROUTING_SUFFIX
             value: "${ROUTING_SUFFIX}"
-          - name: CHE_OAUTH_SERVICE__MODE
-            value: "embedded"
-          - name: CHE_FABRIC8_STANDALONE
-            value: "true"
           image: ${IMAGE_RH_CHE}:${RH_CHE_VERSION}
           imagePullPolicy: "${PULL_POLICY}"
           livenessProbe:
@@ -255,13 +256,6 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 120
             timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /api/system/state
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 15
-            timeoutSeconds: 60
           name: rhche
           ports:
           - containerPort: 8080
@@ -272,6 +266,13 @@ objects:
           - containerPort: 8888
             name: jgroups-ping
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/system/state
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            timeoutSeconds: 60
           resources:
             limits:
               memory: 750Mi
@@ -295,7 +296,7 @@ parameters:
 - name: IMAGE_RH_CHE
   displayName: RhChe server image
   description: RhChe server Docker image.
-  value: registry.devshift.net/che/rh-che-server
+  value: quay.io/openshiftio/che-rh-che-server
 - name: PROTOCOL
   displayName: https or http protocol
   description: Protocol to be used in Che communications
@@ -311,7 +312,7 @@ parameters:
 - name: STRATEGY
   displayName: Update Strategy
   description: Che server update strategy. Defaults to Recreate. Use Rolling only if Che deployment does not use PVC
-  value: 'Recreate'
+  value: 'Rolling'
 - name: PULL_POLICY
   displayName: Che server image pull policy
   description: Pull the image only if not present in the local registry by default. Can be 'Always' and 'Never'

--- a/openshift/minishift-addons/rhche/templates/rh-che.config.yaml
+++ b/openshift/minishift-addons/rhche/templates/rh-che.config.yaml
@@ -1,32 +1,39 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: rhche
 type: Opaque
 data:
+  che-fabric8-multitenant: "true"
+  che-keycloak-client-id: "che-public"
+  che-keycloak-oidc-provider: "NULL"
+  che-keycloak-realm: "che"
+  che-keycloak-use-nonce: "false"
+  che-limits-user-workspaces-run-count: "1"
+  che.logs.dir: "/data/logs"
+  che-openshift-precreate-subpaths: "false"
+  che-openshift-secure-routes: "false"
+  che-secure-external-urls: "false"
+  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
+  che.workspace.agent.dev.inactive_stop_timeout_ms: "900000"
+  che-workspace-logs: "/workspace_logs"
+  che-workspace-server-ping-success-threshold: "2"
+  che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
+  enable-workspaces-autostart: "false"
   infra-machine-start-timeout: "5"
   infra-pvc-strategy: "common"
   infra-trust-certs: "true"
-  multi-user: "true"
-  workspace-storage: "/home/user/che/workspaces"
   local-conf-dir: "/etc/conf"
-  che.logs.dir: "/data/logs"
   log-level: "INFO"
+  multi-user: "true"
   remote-debugging-enabled: "true"
   workspaces-memory-limit: "2400"
   workspaces-memory-limit-max: "2400mb"
-  enable-workspaces-autostart: "false"
-  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
-  che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
-  che-openshift-secure-routes: "false"
-  che-secure-external-urls: "false"
-  che-openshift-precreate-subpaths: "false"
-  che-fabric8-multitenant: "true"
-  che-workspace-logs: "/workspace_logs"
-  che-keycloak-realm: "che"
-  che-keycloak-client-id: "che-public"
-  che-keycloak-oidc-provider: "NULL"
-  che-keycloak-use-nonce: "false"
-  che-workspace-server-ping-success-threshold: "2"
-  che-limits-user-workspaces-run-count: "1"
-  che.workspace.agent.dev.inactive_stop_timeout_ms: "900000"
+  workspace-storage: "/home/user/che/workspaces"

--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -1,3 +1,10 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+---
 kind: Template
 apiVersion: v1
 metadata:
@@ -26,6 +33,19 @@ objects:
     selector:
       app: rhche
 - apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: rhche
+    name: rhche
+  spec:
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: rhche-host
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
@@ -47,109 +67,25 @@ objects:
       spec:
         containers:
         - env:
-          - name: CHE_HOST
+          - name: CHE_API
             valueFrom:
               configMapKeyRef:
-                key: che-host
-                name: rhche
-          - name: CHE_WORKSPACE_STORAGE
-            valueFrom:
-              configMapKeyRef:
-                key: workspace-storage
-                name: rhche
-          - name: CHE_LOGS_DIR
-            valueFrom:
-              configMapKeyRef:
-                key: che.logs.dir
-                name: rhche
-          - name: CHE_LOCAL_CONF_DIR
-            valueFrom:
-              configMapKeyRef:
-                key: local-conf-dir
-                name: rhche
-          - name: CHE_INFRA_OPENSHIFT_PROJECT
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: CHE_PREDEFINED_STACKS_RELOAD__ON__START
-            valueFrom:
-              configMapKeyRef:
-                key: che.predefined.stacks.reload_on_start
-                name: rhche
-          - name: CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS
-            valueFrom:
-              configMapKeyRef:
-                key: che.workspace.agent.dev.inactive_stop_timeout_ms
-                name: rhche
-          - name: CHE_LOG_LEVEL
-            valueFrom:
-              configMapKeyRef:
-                key: log-level
-                name: rhche
-          - name: CHE_PORT
-            valueFrom:
-              configMapKeyRef:
-                key: port
+                key: che-api
                 name: rhche
           - name: CHE_DEBUG_SERVER
             valueFrom:
               configMapKeyRef:
                 key: remote-debugging-enabled
                 name: rhche
-          - name: CHE_LIMITS_WORKSPACE_ENV_RAM
+          - name: CHE_FABRIC8_ANALYTICS_SEGMENT__WRITE__KEY
             valueFrom:
               configMapKeyRef:
-                key: workspaces-memory-limit-max
+                key: analytics.segment_write_key
                 name: rhche
-          - name: CHE_WORKSPACE_DEFAULT__MEMORY__MB
+          - name: CHE_FABRIC8_ANALYTICS_WOOPRA__DOMAIN
             valueFrom:
               configMapKeyRef:
-                key: workspaces-memory-limit
-                name: rhche
-          - name: CHE_WORKSPACE_AUTO__START
-            valueFrom:
-              configMapKeyRef:
-                key: enable-workspaces-autostart
-                name: rhche
-          - name: CHE_INFRA_KUBERNETES_PVC_QUANTITY
-            valueFrom:
-              configMapKeyRef:
-                key: workspaces-pvc-storage-size
-                name: rhche
-          - name: JAVA_OPTS
-            valueFrom:
-              configMapKeyRef:
-                key: che-server-java-opts
-                name: rhche
-          - name: CHE_WORKSPACE_JAVA__OPTIONS
-            valueFrom:
-              configMapKeyRef:
-                key: che-workspaces-java-opts
-                name: rhche
-          - name: CHE_INFRA_OPENSHIFT_TLS__ENABLED
-            valueFrom:
-              configMapKeyRef:
-                key: che-openshift-secure-routes
-                name: rhche
-          - name: CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS
-            valueFrom:
-              configMapKeyRef:
-                key: che-openshift-precreate-subpaths
-                name: rhche
-          - name: CHE_KEYCLOAK_GITHUB_ENDPOINT
-            valueFrom:
-              configMapKeyRef:
-                key: keycloak-github-endpoint
-                name: rhche
-          - name: CHE_FABRIC8_MULTITENANT
-            valueFrom:
-              configMapKeyRef:
-                key: che-fabric8-multitenant
-                name: rhche
-          - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
-            valueFrom:
-              configMapKeyRef:
-                key: che-fabric8-user-service-endpoint
+                key: analytics.woopra_domain
                 name: rhche
           - name: CHE_FABRIC8_AUTH_ENDPOINT
             valueFrom:
@@ -161,46 +97,62 @@ objects:
               configMapKeyRef:
                 key: che-fabric8-multicluster-oso-proxy-url
                 name: rhche
-          - name: CHE_API
+          - name: CHE_FABRIC8_MULTITENANT
             valueFrom:
               configMapKeyRef:
-                key: che-api
+                key: che-fabric8-multitenant
                 name: rhche
-          - name: CHE_WEBSOCKET_ENDPOINT
+          - name: CHE_FABRIC8_USER__SERVICE_ENDPOINT
             valueFrom:
               configMapKeyRef:
-                key: che-websocket-endpoint
+                key: che-fabric8-user-service-endpoint
                 name: rhche
-          - name: CHE_WORKSPACE_LOGS_ROOT__DIR
+          - name: CHE_HOST
             valueFrom:
               configMapKeyRef:
-                key: che-workspace-logs
+                key: che-host
                 name: rhche
-          - name: CHE_KEYCLOAK_AUTH__SERVER__URL
+          - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
             valueFrom:
               configMapKeyRef:
-                key: che-keycloak-auth-server-url
+                key: infra-bootstrapper-binary-url
                 name: rhche
-          - name: CHE_KEYCLOAK_REALM
+          - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
             valueFrom:
               configMapKeyRef:
-                key: che-keycloak-realm
+                key: infra-machine-start-timeout
                 name: rhche
-          - name: CHE_KEYCLOAK_CLIENT__ID
+          - name: CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS
             valueFrom:
               configMapKeyRef:
-                key: che-keycloak-client-id
+                key: che-openshift-precreate-subpaths
                 name: rhche
-          - name: CHE_KEYCLOAK_OIDC__PROVIDER
+          - name: CHE_INFRA_KUBERNETES_PVC_QUANTITY
             valueFrom:
               configMapKeyRef:
-                key: che-keycloak-oidc-provider
+                key: workspaces-pvc-storage-size
                 name: rhche
-          - name: CHE_KEYCLOAK_USE__NONCE
+          - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
             valueFrom:
               configMapKeyRef:
-                key: che-keycloak-use-nonce
+                key: infra-pvc-strategy
                 name: rhche
+          - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
+            valueFrom:
+              configMapKeyRef:
+                key: infra-trust-certs
+                name: rhche
+          - name: CHE_INFRA_OPENSHIFT_PROJECT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CHE_INFRA_OPENSHIFT_TLS__ENABLED
+            valueFrom:
+              configMapKeyRef:
+                key: che-openshift-secure-routes
+                name: rhche
+          - name: CHE_INFRASTRUCTURE_ACTIVE
+            value: "openshift"
           - name: CHE_JDBC_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -216,62 +168,145 @@ objects:
               secretKeyRef:
                   key: che.jdbc.username
                   name: rhche
-          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
-            valueFrom:
-              secretKeyRef:
-                  key: service.account.secret
-                  name: rhche
-          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
-            valueFrom:
-              secretKeyRef:
-                  key: service.account.id
-                  name: rhche
-          - name: CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD
+          - name: CHE_KEYCLOAK_AUTH__SERVER__URL
             valueFrom:
               configMapKeyRef:
-                key: che-workspace-server-ping-success-threshold
+                key: che-keycloak-auth-server-url
+                name: rhche
+          - name: CHE_KEYCLOAK_CLIENT__ID
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-client-id
+                name: rhche
+          - name: CHE_KEYCLOAK_GITHUB_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                key: keycloak-github-endpoint
+                name: rhche
+          - name: CHE_KEYCLOAK_JS__ADAPTER__URL
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-js-adapter-url
+                name: rhche
+          - name: CHE_KEYCLOAK_OIDC__PROVIDER
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-oidc-provider
+                name: rhche
+          - name: CHE_KEYCLOAK_REALM
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-realm
+                name: rhche
+          - name: CHE_KEYCLOAK_USE__NONCE
+            valueFrom:
+              configMapKeyRef:
+                key: che-keycloak-use-nonce
                 name: rhche
           - name: CHE_LIMITS_USER_WORKSPACES_RUN_COUNT
             valueFrom:
               configMapKeyRef:
                 key: che-limits-user-workspaces-run-count
                 name: rhche
-          - name: CHE_INFRASTRUCTURE_ACTIVE
-            value: "openshift"
-          - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
+          - name: CHE_LIMITS_WORKSPACE_ENV_RAM
             valueFrom:
               configMapKeyRef:
-                key: infra-bootstrapper-binary-url
+                key: workspaces-memory-limit-max
                 name: rhche
-          - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
+          - name: CHE_LOCAL_CONF_DIR
             valueFrom:
               configMapKeyRef:
-                key: infra-machine-start-timeout
+                key: local-conf-dir
                 name: rhche
-          - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
+          - name: CHE_LOG_LEVEL
             valueFrom:
               configMapKeyRef:
-                key: infra-pvc-strategy
-                name: rhche
-          - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
-            valueFrom:
-              configMapKeyRef:
-                key: infra-trust-certs
-                name: rhche
-          - name: CHE_MULTIUSER
-            valueFrom:
-              configMapKeyRef:
-                key: multi-user
+                key: log-level
                 name: rhche
           - name: CHE_LOGS_APPENDERS_IMPL
             valueFrom:
               configMapKeyRef:
                 key: logs-encoding
                 name: rhche
+          - name: CHE_LOGS_DIR
+            valueFrom:
+              configMapKeyRef:
+                key: che.logs.dir
+                name: rhche
           - name: CHE_LOGS_SENTRY_LEVEL
             valueFrom:
               configMapKeyRef:
                 key: che-logs-sentry-level
+                name: rhche
+          - name: CHE_MULTIUSER
+            valueFrom:
+              configMapKeyRef:
+                key: multi-user
+                name: rhche
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                  key: service.account.id
+                  name: rhche
+          - name: CHE_OPENSHIFT_SERVICE__ACCOUNT_SECRET
+            valueFrom:
+              secretKeyRef:
+                  key: service.account.secret
+                  name: rhche
+          - name: CHE_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: port
+                name: rhche
+          - name: CHE_PREDEFINED_STACKS_RELOAD__ON__START
+            valueFrom:
+              configMapKeyRef:
+                key: che.predefined.stacks.reload_on_start
+                name: rhche
+          - name: CHE_WEBSOCKET_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                key: che-websocket-endpoint
+                name: rhche
+          - name: CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS
+            valueFrom:
+              configMapKeyRef:
+                key: che.workspace.agent.dev.inactive_stop_timeout_ms
+                name: rhche
+          - name: CHE_WORKSPACE_AUTO__START
+            valueFrom:
+              configMapKeyRef:
+                key: enable-workspaces-autostart
+                name: rhche
+          - name: CHE_WORKSPACE_DEFAULT__MEMORY__MB
+            valueFrom:
+              configMapKeyRef:
+                key: workspaces-memory-limit
+                name: rhche
+          - name: CHE_WORKSPACE_JAVA__OPTIONS
+            valueFrom:
+              configMapKeyRef:
+                key: che-workspaces-java-opts
+                name: rhche
+          - name: CHE_WORKSPACE_LOGS_ROOT__DIR
+            valueFrom:
+              configMapKeyRef:
+                key: che-workspace-logs
+                name: rhche
+          - name: CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD
+            valueFrom:
+              configMapKeyRef:
+                key: che-workspace-server-ping-success-threshold
+                name: rhche
+          - name: CHE_WORKSPACE_STORAGE
+            valueFrom:
+              configMapKeyRef:
+                key: workspace-storage
+                name: rhche
+          - name: JAVA_OPTS
+            valueFrom:
+              configMapKeyRef:
+                key: che-server-java-opts
                 name: rhche
           - name: SENTRY_DSN
             valueFrom:
@@ -290,21 +325,6 @@ objects:
                 name: rhche
           - name: SENTRY_RELEASE
             value: ${IMAGE_TAG}
-          - name: CHE_FABRIC8_ANALYTICS_SEGMENT__WRITE__KEY
-            valueFrom:
-              configMapKeyRef:
-                key: analytics.segment_write_key
-                name: rhche
-          - name: CHE_FABRIC8_ANALYTICS_WOOPRA__DOMAIN
-            valueFrom:
-              configMapKeyRef:
-                key: analytics.woopra_domain
-                name: rhche
-          - name: CHE_KEYCLOAK_JS__ADAPTER__URL
-            valueFrom:
-              configMapKeyRef:
-                key: che-keycloak-js-adapter-url
-                name: rhche
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -335,19 +355,6 @@ objects:
         serviceAccountName: rhche
     triggers:
     - type: ConfigChange
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: rhche
-    name: rhche
-  spec:
-    tls:
-      insecureEdgeTerminationPolicy: Redirect
-      termination: edge
-    to:
-      kind: Service
-      name: rhche-host
 parameters:
 - name: IMAGE
   value: quay.io/openshiftio/rhel-che-rh-che-server

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -1,53 +1,59 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: rhche
 type: Opaque
 data:
+  analytics.segment_write_key: 'NULL' 
+  analytics.woopra_domain: 'NULL'
+  che-api: "https://che.prod-preview.openshift.io/api"
+  che-fabric8-auth-endpoint: "https://auth.prod-preview.openshift.io"
+  che-fabric8-multicluster-oso-proxy-url: "https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com"
+  che-fabric8-multitenant: "true"
+  che-fabric8-user-service-endpoint: "https://api.prod-preview.openshift.io/api/user/services"
+  che-host: "che.prod-preview.openshift.io"
+  che-keycloak-auth-server-url: "NULL"
+  che-keycloak-client-id: "740650a2-9c44-4db5-b067-a3d1b2cd2d01"
+  che-keycloak-js-adapter-url: "/_app/keycloak/RhCheKeycloak.js"
+  che-keycloak-oidc-provider: "https://auth.prod-preview.openshift.io/api"
+  che-keycloak-realm: "NULL"
+  che-keycloak-use-nonce: "false"
+  che-limits-user-workspaces-run-count: "1"
+  che.logs.dir: "/data/logs"
+  che-logs-sentry-dsn: 'NULL'
+  che-logs-sentry-level: 'WARN'
+  che-openshift-precreate-subpaths: "false"
+  che-openshift-secure-routes: "true"
+  che.predefined.stacks.reload_on_start: "true"
+  che-secure-external-urls: "true"
+  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
+  che-websocket-endpoint: "wss://che.prod-preview.openshift.io/api/websocket"
+  che.workspace.agent.dev.inactive_stop_timeout_ms: "900000"
+  che-workspace-logs: "/workspace_logs"
+  che-workspace-server-ping-success-threshold: "2"
+  che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
+  enable-workspaces-autostart: "true"
   infra-bootstrapper-binary-url: "https://che.prod-preview.openshift.io/agent-binaries/linux_amd64/bootstrapper/bootstrapper"
   infra-machine-start-timeout: "5"
   infra-pvc-strategy: "common"
   infra-trust-certs: "true"
-  multi-user: "true"
-  che-host: "che.prod-preview.openshift.io"
-  workspace-storage: "/home/user/che/workspaces"
+  keycloak-github-endpoint: "https://auth.prod-preview.openshift.io/api/token?for=https://github.com"
   local-conf-dir: "/etc/conf"
-  che.logs.dir: "/data/logs"
-  che.predefined.stacks.reload_on_start: "true"
   log-level: "INFO"
+  logs-encoding: "json"
+  multi-user: "true"
   port: "8080"
   remote-debugging-enabled: "false"
+  sentry-environment: 'dev'
+  sentry-stacktrace-app-packages: 'com.redhat,org.eclipse.che'
   workspaces-memory-limit: "3000"
   workspaces-memory-limit-max: "3gb"
-  enable-workspaces-autostart: "true"
-  keycloak-github-endpoint: "https://auth.prod-preview.openshift.io/api/token?for=https://github.com"
-  che-server-java-opts: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms50m -Xmx180m -Dfile.encoding=UTF8"
-  che-workspaces-java-opts: "-XX:+UseG1GC -XX:+UseStringDeduplication -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:MaxRAM=1200m -Xms256m"
-  che-openshift-secure-routes: "true"
-  che-secure-external-urls: "true"
-  che-openshift-precreate-subpaths: "false"
-  che-fabric8-multitenant: "true"
-  che-fabric8-user-service-endpoint: "https://api.prod-preview.openshift.io/api/user/services"
-  che-fabric8-auth-endpoint: "https://auth.prod-preview.openshift.io"
-  che-fabric8-multicluster-oso-proxy-url: "https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com"
-  che-api: "https://che.prod-preview.openshift.io/api"
-  che-websocket-endpoint: "wss://che.prod-preview.openshift.io/api/websocket"
-  che-workspace-logs: "/workspace_logs"
-  che-keycloak-auth-server-url: "NULL"
-  che-keycloak-realm: "NULL"
-  che-keycloak-client-id: "740650a2-9c44-4db5-b067-a3d1b2cd2d01"
-  che-keycloak-oidc-provider: "https://auth.prod-preview.openshift.io/api"
-  che-keycloak-js-adapter-url: "/_app/keycloak/RhCheKeycloak.js"
-  che-keycloak-use-nonce: "false"
-  che-workspace-server-ping-success-threshold: "2"
-  che-limits-user-workspaces-run-count: "1"
-  che.workspace.agent.dev.inactive_stop_timeout_ms: "900000"
-  logs-encoding: "json"
-  che-logs-sentry-level: 'WARN'
-  che-logs-sentry-dsn: 'NULL'
-  sentry-stacktrace-app-packages: 'com.redhat,org.eclipse.che'
-  sentry-environment: 'dev'
-  analytics.segment_write_key: 'NULL' 
-  analytics.woopra_domain: 'NULL'
   workspaces-pvc-storage-size: '1Gi'
-  
+  workspace-storage: "/home/user/che/workspaces"


### PR DESCRIPTION
### What does this PR do?
Adds some minor improvements / modifications to the multi-user minishift addon for rhche.

- Update image used in minishift addon to use quay.io instead of registry.devshift.net (old version defaulted to a 6.7.1-based deployment)
- Sort templates used to deploy minishift addon and local deployments to more easily compare addon to what is deployed in `./dev-scripts/deploy_custom_rh-che.sh`. This is helpful for e.g. highlighting differences between local and dev cluster deployments (previously it was impossible to tell what differences were, now a `diff` is possible).
- Add serviceaccount and rolebinding to list of deleted openshift object when removing addon, as they don't seem to be deleted by default if only `rhche` addon is removed
- Update default deploy strategy in minishift addon to "Rolling" to match current use; is still configurable as before

I mostly did this to help myself understand the addon and its differences; I don't see merging it as absolutely necessary but thought I'd share.