### PR TITLE
Changing default image for deploy script from devshift.net to quay.io

### DIFF
--- a/dev-scripts/deploy_custom_rh-che.sh
+++ b/dev-scripts/deploy_custom_rh-che.sh
@@ -45,7 +45,7 @@ export RH_CHE_RUNNING_STANDALONE_SCRIPT="false";
 export RH_CHE_USE_TLS="true"
 
 export RH_CHE_DOCKER_IMAGE_TAG="latest";
-export RH_CHE_DOCKER_REPOSITORY="registry.devshift.net/che/rh-che-server";
+export RH_CHE_DOCKER_REPOSITORY="quay.io/openshiftio/che-rh-che-server";
 export RH_CHE_GITHUB_BRANCH=master;
 
 function unsetVars() {


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Cahnges default che-server image location from `registry.devshift.net/che/rh-che-server` to `quay.io/openshiftio/che-rh-che-server`.

### What issues does this PR fix or reference?


### How have you tested this PR?
Against dev cluster.