### PR TITLE
Separate PR deployments

### DIFF
--- a/.ci/cico_cleanup_dev_cluster.sh
+++ b/.ci/cico_cleanup_dev_cluster.sh
@@ -1,0 +1,54 @@
+#!/bin/env bash
+# Copyright (c) 2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# ERROR CODES:
+# 1 - missing credentials
+# 2 - OpenShift login failed
+
+export OC_VERSION=3.9.33
+export DEV_CLUSTER_URL=https://devtools-dev.ext.devshift.net:8443/
+
+eval "$(./env-toolkit load -f jenkins-env.json -r ^RH_CHE)"
+curl -s "https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz" | tar xvz -C /usr/local/bin
+if [[ -z "${RH_CHE_AUTOMATION_RDU2C_USERNAME}" || -z "${RH_CHE_AUTOMATION_RDU2C_PASSWORD}" ]]; then
+  echo "RDU2C credentials not set"
+  exit 1
+fi
+if oc login ${DEV_CLUSTER_URL} --insecure-skip-tls-verify \
+                               -u "${RH_CHE_AUTOMATION_RDU2C_USERNAME}" \
+                               -p "${RH_CHE_AUTOMATION_RDU2C_PASSWORD}";
+then
+  echo "OpenShift login successful"
+else
+  echo "OpenShift login failed"
+  echo "login: |${RH_CHE_AUTOMATION_RDU2C_USERNAME:0:1}*${RH_CHE_AUTOMATION_RDU2C_USERNAME:7:2}*${RH_CHE_AUTOMATION_RDU2C_USERNAME: -1}|"
+  echo "passwd: |${RH_CHE_AUTOMATION_RDU2C_PASSWORD:0:1}***${RH_CHE_AUTOMATION_RDU2C_PASSWORD: -1}|"
+  exit 2
+fi
+
+PullRequests=$(curl -s https://api.github.com/repos/redhat-developer/rh-che/pulls?state=open | jq '.[].number')
+OCProjects=$(oc projects -q)
+
+while read -r oc_project
+do
+  if [[ "$oc_project" != "prcheck-"* ]]; then
+    continue
+  fi
+  PR_PRESENT="false"
+  while read -r pr_number
+  do
+    if [[ "$oc_project" == *"-$pr_number" ]]; then
+      PR_PRESENT="true"
+    fi
+  done <<< "$PullRequests"
+  if [[ "$PR_PRESENT" == "false" ]]; then
+    echo "PR for project $oc_project not found, deleting."
+    oc delete project $oc_project
+  else
+    echo "PR for project $oc_project still open"
+  fi
+done <<< "$OCProjects"

--- a/.ci/cico_do_docker_build_tag_push.sh
+++ b/.ci/cico_do_docker_build_tag_push.sh
@@ -27,10 +27,16 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
     ${ABSOLUTE_PATH}/../assembly/assembly-main/target/eclipse-che-${RH_DIST_SUFFIX}-*${RH_NO_DASHBOARD_SUFFIX}*)
       TAG=${UPSTREAM_TAG}-${RH_TAG_DIST_SUFFIX}-no-dashboard-${RH_CHE_TAG}
       NIGHTLY=nightly-${RH_TAG_DIST_SUFFIX}-no-dashboard
+      if [ "$PR_CHECK_BUILD" == "true" ]; then
+        TAG=${RH_TAG_DIST_SUFFIX}-no-dashhoard-${RH_PULL_REQUEST_ID}
+      fi
       ;;
     ${ABSOLUTE_PATH}/../assembly/assembly-main/target/eclipse-che-${RH_DIST_SUFFIX}*)
       TAG=${UPSTREAM_TAG}-${RH_TAG_DIST_SUFFIX}-${RH_CHE_TAG}
       NIGHTLY=nightly-${RH_TAG_DIST_SUFFIX}
+      if [ "$PR_CHECK_BUILD" == "true" ]; then
+        TAG=${RH_TAG_DIST_SUFFIX}-${RH_PULL_REQUEST_ID}
+      fi
       # File che_image_tag.env will be used by the verification script to
       # retrieve the image tag to promote to production. That's the only
       # mechanism we have found to share the tag amongs the two scripts

--- a/config
+++ b/config
@@ -37,6 +37,7 @@ export PATH=$NPM_CONFIG_PREFIX/bin:$PATH
 export RH_DIST_SUFFIX=fabric8
 if [ "$PR_CHECK_BUILD" == "true" ]; then
   export RH_TAG_DIST_SUFFIX=rhcheautomation
+  export RH_PULL_REQUEST_ID="${ghprbPullId}"
 else
   export RH_TAG_DIST_SUFFIX=fabric8
 fi

--- a/dockerfiles/pr-check/Dockerfile
+++ b/dockerfiles/pr-check/Dockerfile
@@ -11,6 +11,6 @@ USER root
 RUN yum update --assumeyes && \
     yum install --assumeyes docker tree git patch pcp bzip2 golang make java-1.8.0-openjdk java-1.8.0-openjdk-devel centos-release-scl && \
     yum install --assumeyes rh-maven33 rh-nodejs4 && yum clean all && rm -rf /var/cache/yum && \
-    scl enable rh-nodejs4 "npm install --global gulp-cli" && \
+    scl enable rh-nodejs4 "npm install --global gulp-cli bower" && \
     cd /tmp/ && git clone https://github.com/redhat-developer/rh-che.git && \
-    scl enable rh-maven33 rh-nodejs4 "mvn -B -f /tmp/rh-che/ clean install" && rm -rf /tmp/rh-che/
+    scl enable rh-maven33 rh-nodejs4 "mvn -B -f /tmp/rh-che/ -Pnative clean install" && rm -rf /tmp/rh-che/


### PR DESCRIPTION
### What does this PR do?
Creates a separate namespace for every open PR, leaving the servers deployed for testing until PR is closed. Then the namespaces will be deleted. This should allow concurrency and faster, more responsive PR Check.

- [X] Separate deployments into specific namespace
- [X] Run tests against specific deployment
- [X] Investigate possibilities of cleanup job
- [x] Implement cleanup job

### What issues does this PR fix or reference?
edhat-developer/che-functional-tests/issues/357

### How have you tested this PR?
pr-check testing.