### PR TITLE
Adding support of 'CHE_WORKSPACE_PLUGIN__REGISTRY__URL' required for workspace.next

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -253,6 +253,11 @@ objects:
               secretKeyRef:
                   key: service.account.secret
                   name: rhche
+          - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
+            valueFrom:
+              configMapKeyRef:
+                key: plugin-registry-url
+                name: rhche
           - name: CHE_PORT
             valueFrom:
               configMapKeyRef:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -49,6 +49,7 @@ data:
   log-level: "INFO"
   logs-encoding: "json"
   multi-user: "true"
+  plugin-registry-url: 'https://che-plugin-registry.prod-preview.openshift.io/'
   port: "8080"
   remote-debugging-enabled: "false"
   sentry-environment: 'dev'


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Adding support of 'CHE_WORKSPACE_PLUGIN__REGISTRY__URL' required for workspace.next

### What issues does this PR fix or reference?
Related HK issue - https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2339
