### PR TITLE
Use custom timeout in waitStatus

### DIFF
--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
@@ -32,7 +32,6 @@ import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.user.TestUser;
-import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.workspace.MemoryMeasure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,21 +146,7 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
   public void waitStatus(String workspaceName, String userName, WorkspaceStatus expectedStatus)
       throws Exception {
     int timeoutInMins = 3;
-    int loops = timeoutInMins * 60;
-
-    WorkspaceStatus status = null;
-    for (int i = 0; i < loops; i++) {
-      status = getByName(workspaceName, userName).getStatus();
-      if (status == expectedStatus) {
-        return;
-      } else {
-        WaitUtils.sleepQuietly(1);
-      }
-    }
-
-    throw new IllegalStateException(
-        String.format(
-            "Workspace %s, status=%s, expected status=%s", workspaceName, status, expectedStatus));
+    waitStatus(workspaceName, userName, expectedStatus, timeoutInMins * 60);
   }
 
   public void startWithoutPatch(String id) throws Exception {

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/client/RhCheTestWorkspaceServiceClient.java
@@ -102,7 +102,7 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
     try {
       this.cheStarterWrapper.checkIsRunning(this.token);
       this.cheStarterWrapper.startWorkspace(workspaceId, workspaceName, token);
-      waitStatus(workspaceName, owner.getName(), WorkspaceStatus.RUNNING);
+      waitStatus(workspaceName, owner.getName(), WorkspaceStatus.RUNNING, 300);
       LOG.info("Workspace " + workspaceName + "is running.");
     } catch (Exception e) {
       LOG.error("Failed to start workspace \"" + workspaceName + "\".");
@@ -137,16 +137,6 @@ public class RhCheTestWorkspaceServiceClient extends AbstractTestWorkspaceServic
         .fromUrl(getNameBasedUrl(workspaceName, owner.getName()))
         .request()
         .asDto(WorkspaceDto.class);
-  }
-
-  // Overriding this method to be able to set another timeout
-  // TODO this feature is temporary - should be changed in upstream. Issue #356 in
-  // che-functional-tests repo
-  @Override
-  public void waitStatus(String workspaceName, String userName, WorkspaceStatus expectedStatus)
-      throws Exception {
-    int timeoutInMins = 3;
-    waitStatus(workspaceName, userName, expectedStatus, timeoutInMins * 60);
   }
 
   public void startWithoutPatch(String id) throws Exception {


### PR DESCRIPTION
### What does this PR do?
Uses upstream method for custom timeout - logic moved, replaced only by function call.

### What issues does this PR fix or reference?
Upstream change - https://github.com/eclipse/che/pull/11430

### How have you tested this PR?
localy