### PR TITLE
Change display resolution for functional tests.

### DIFF
--- a/dockerfiles/functional-tests/docker-entrypoint.sh
+++ b/dockerfiles/functional-tests/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo -n Running Xvfb...
 nohup chromedriver &
-/usr/bin/Xvfb :99 -screen 0 1024x768x24 +extension RANDR
+/usr/bin/Xvfb :99 -screen 0 1920x1080x24 +extension RANDR


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Changes resolution of display for running functional tests.
The resolution was 1024x768, which is pretty small display for current standards and caused some troubles in functional-tests as for example: https://github.com/redhat-developer/che-functional-tests/issues/369

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/369

### How have you tested this PR?
