### PR TITLE
Add Quay imagepullsecrets to rhche ServiceAccount

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -14,6 +14,8 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ServiceAccount
+  imagePullSecrets:
+  - name: quay.io
   metadata:
     labels:
       app: rhche


### PR DESCRIPTION
### What does this PR do?
This PR will add an entry with the quay imagepullsecret set in the SA definition.


### What issues does this PR fix or reference?
When this template processed and applied, the existing `rhche` SA that has the `quay.io` imagepullsecrets linked would get overwritten, and unlink the image pull secret. This leads to a permission denied error pulling the image. 

### How have you tested this PR?
