### PR TITLE
Start workspaces like in upstream tests

### DIFF
--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -73,10 +73,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumClassModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumClassModule.java
@@ -44,7 +44,7 @@ public class RhCheSeleniumClassModule extends AbstractModule {
             && field.isAnnotationPresent(InjectTestWorkspace.class)) {
           encounter.register(
               new RhCheTestWorkspaceInjector<>(
-                  field, field.getAnnotation(InjectTestWorkspace.class), injectorProvider));
+                  field, field.getAnnotation(InjectTestWorkspace.class), injectorProvider.get()));
         }
       }
     }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumClassModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumClassModule.java
@@ -22,7 +22,6 @@ import com.google.inject.spi.TypeListener;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceImpl;
 import java.lang.reflect.Field;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
-import org.eclipse.che.selenium.core.workspace.TestWorkspaceInjector;
 
 public class RhCheSeleniumClassModule extends AbstractModule {
   @Override
@@ -44,8 +43,8 @@ public class RhCheSeleniumClassModule extends AbstractModule {
         if (field.getType() == RhCheTestWorkspaceImpl.class
             && field.isAnnotationPresent(InjectTestWorkspace.class)) {
           encounter.register(
-              new TestWorkspaceInjector<>(
-                  field, field.getAnnotation(InjectTestWorkspace.class), injectorProvider.get()));
+              new RhCheTestWorkspaceInjector<>(
+                  field, field.getAnnotation(InjectTestWorkspace.class), injectorProvider));
         }
       }
     }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheSeleniumSuiteModule.java
@@ -15,24 +15,18 @@ import static com.google.inject.name.Names.named;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
-import com.redhat.che.selenium.core.client.RhCheTestWorkspaceServiceClient;
 import com.redhat.che.selenium.core.workspace.ProvidedWorkspace;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceImpl;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceProvider;
-import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
-import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClientFactory;
 import org.eclipse.che.selenium.core.configuration.SeleniumTestConfiguration;
 import org.eclipse.che.selenium.core.configuration.TestConfiguration;
 import org.eclipse.che.selenium.core.provider.DefaultTestUserProvider;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.user.MultiUserCheDefaultTestUserProvider;
 import org.eclipse.che.selenium.core.user.TestUser;
-import org.eclipse.che.selenium.core.workspace.TestWorkspace;
-import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 
 public class RhCheSeleniumSuiteModule extends AbstractModule {
@@ -44,30 +38,11 @@ public class RhCheSeleniumSuiteModule extends AbstractModule {
     bind(DefaultTestUserProvider.class).to(MultiUserCheDefaultTestUserProvider.class);
     bind(DefaultTestUser.class).toProvider(DefaultTestUserProvider.class);
     bind(TestUser.class).to(DefaultTestUser.class);
-    install(
-        new FactoryModuleBuilder()
-            .implement(TestWorkspaceServiceClient.class, RhCheTestWorkspaceServiceClient.class)
-            .build(TestWorkspaceServiceClientFactory.class));
-    bind(TestWorkspaceServiceClient.class).to(RhCheTestWorkspaceServiceClient.class);
-    bind(TestWorkspaceProvider.class).to(RhCheTestWorkspaceProvider.class).asEagerSingleton();
     if (config.getMap().get("che.workspaceName") == null) {
       bind(String.class)
           .annotatedWith(Names.named("che.workspaceName"))
           .toProvider(Providers.<String>of(null));
     }
-  }
-
-  @Provides
-  public TestWorkspace getWorkspace(
-      TestWorkspaceProvider workspaceProvider,
-      DefaultTestUser testUser,
-      @Named("workspace.default_memory_gb") int defaultMemoryGb)
-      throws Exception {
-    TestWorkspace ws =
-        workspaceProvider.createWorkspace(
-            testUser, defaultMemoryGb, WorkspaceTemplate.DEFAULT, true);
-    ws.await();
-    return ws;
   }
 
   @Provides

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheTestWorkspaceInjector.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheTestWorkspaceInjector.java
@@ -11,82 +11,22 @@
  */
 package com.redhat.che.selenium.core;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.lang.String.format;
-
 import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.MembersInjector;
-import com.google.inject.Provider;
-import com.google.inject.name.Names;
-import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceImpl;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceProvider;
 import java.lang.reflect.Field;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.workspace.AbstractTestWorkspaceInjector;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
+import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
 
-public class RhCheTestWorkspaceInjector<T> implements MembersInjector<T> {
-  private final Field field;
-  private final InjectTestWorkspace injectTestWorkspace;
-  private final Provider<Injector> injectorProvider;
+public class RhCheTestWorkspaceInjector<T> extends AbstractTestWorkspaceInjector<T> {
 
   public RhCheTestWorkspaceInjector(
-      Field field, InjectTestWorkspace injectTestWorkspace, Provider<Injector> injectorProvider) {
-    this.field = field;
-    this.injectTestWorkspace = injectTestWorkspace;
-    this.injectorProvider = injectorProvider;
+      Field field, InjectTestWorkspace injectTestWorkspace, Injector injector) {
+    super(field, injectTestWorkspace, injector);
   }
 
   @Override
-  public void injectMembers(T instance) {
-    Injector injector = injectorProvider.get();
-
-    RhCheTestWorkspaceProvider testWorkspaceProvider =
-        injector.getInstance(RhCheTestWorkspaceProvider.class);
-    int workspaceDefaultMemoryGb =
-        injector.getInstance(Key.get(int.class, Names.named("workspace.default_memory_gb")));
-
-    try {
-      DefaultTestUser testUser =
-          isNullOrEmpty(injectTestWorkspace.user())
-              ? injector.getInstance(DefaultTestUser.class)
-              : findInjectedUser(instance, injectTestWorkspace.user());
-
-      RhCheTestWorkspaceImpl testWorkspace =
-          (RhCheTestWorkspaceImpl)
-              testWorkspaceProvider.createWorkspace(
-                  testUser, 0, null, injectTestWorkspace.startAfterCreation());
-      testWorkspace.await();
-
-      field.setAccessible(true);
-      field.set(instance, testWorkspace);
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to instantiate workspace in " + instance.getClass().getName(), e);
-    }
-  }
-
-  private DefaultTestUser findInjectedUser(T instance, String userEmail) {
-    for (Field field : instance.getClass().getDeclaredFields()) {
-      if (field.getType() == DefaultTestUser.class) {
-        field.setAccessible(true);
-
-        DefaultTestUser testUser;
-        try {
-          testUser = (DefaultTestUser) field.get(instance);
-        } catch (IllegalAccessException e) {
-          throw new IllegalArgumentException(e);
-        }
-
-        if (testUser != null && testUser.getEmail().equals(userEmail)) {
-          return testUser;
-        }
-      }
-    }
-
-    throw new IllegalArgumentException(
-        format(
-            "User %s not found or isn't instantiated in %s",
-            userEmail, instance.getClass().getName()));
+  protected TestWorkspaceProvider getTestWorkspaceProvider() {
+    return injector.getInstance(RhCheTestWorkspaceProvider.class);
   }
 }

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheTestWorkspaceInjector.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/RhCheTestWorkspaceInjector.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.selenium.core;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.MembersInjector;
+import com.google.inject.Provider;
+import com.google.inject.name.Names;
+import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceImpl;
+import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceProvider;
+import java.lang.reflect.Field;
+import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
+
+public class RhCheTestWorkspaceInjector<T> implements MembersInjector<T> {
+  private final Field field;
+  private final InjectTestWorkspace injectTestWorkspace;
+  private final Provider<Injector> injectorProvider;
+
+  public RhCheTestWorkspaceInjector(
+      Field field, InjectTestWorkspace injectTestWorkspace, Provider<Injector> injectorProvider) {
+    this.field = field;
+    this.injectTestWorkspace = injectTestWorkspace;
+    this.injectorProvider = injectorProvider;
+  }
+
+  @Override
+  public void injectMembers(T instance) {
+    Injector injector = injectorProvider.get();
+
+    RhCheTestWorkspaceProvider testWorkspaceProvider =
+        injector.getInstance(RhCheTestWorkspaceProvider.class);
+    int workspaceDefaultMemoryGb =
+        injector.getInstance(Key.get(int.class, Names.named("workspace.default_memory_gb")));
+
+    try {
+      DefaultTestUser testUser =
+          isNullOrEmpty(injectTestWorkspace.user())
+              ? injector.getInstance(DefaultTestUser.class)
+              : findInjectedUser(instance, injectTestWorkspace.user());
+
+      RhCheTestWorkspaceImpl testWorkspace =
+          (RhCheTestWorkspaceImpl)
+              testWorkspaceProvider.createWorkspace(
+                  testUser, 0, null, injectTestWorkspace.startAfterCreation());
+      testWorkspace.await();
+
+      field.setAccessible(true);
+      field.set(instance, testWorkspace);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to instantiate workspace in " + instance.getClass().getName(), e);
+    }
+  }
+
+  private DefaultTestUser findInjectedUser(T instance, String userEmail) {
+    for (Field field : instance.getClass().getDeclaredFields()) {
+      if (field.getType() == DefaultTestUser.class) {
+        field.setAccessible(true);
+
+        DefaultTestUser testUser;
+        try {
+          testUser = (DefaultTestUser) field.get(instance);
+        } catch (IllegalAccessException e) {
+          throw new IllegalArgumentException(e);
+        }
+
+        if (testUser != null && testUser.getEmail().equals(userEmail)) {
+          return testUser;
+        }
+      }
+    }
+
+    throw new IllegalArgumentException(
+        format(
+            "User %s not found or isn't instantiated in %s",
+            userEmail, instance.getClass().getName()));
+  }
+}

--- a/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceImpl.java
+++ b/functional-tests/src/main/java/com/redhat/che/selenium/core/workspace/RhCheTestWorkspaceImpl.java
@@ -139,14 +139,23 @@ public class RhCheTestWorkspaceImpl implements TestWorkspace {
         });
   }
 
-  public boolean checkStatus(String status) {
+  public void checkStatus(String status) throws Exception {
+    WorkspaceStatus actualStatus;
     try {
-      WorkspaceStatus actualStatus = workspaceServiceClient.getStatus(id.toString());
-      return status.equals(actualStatus.toString());
+      actualStatus = workspaceServiceClient.getStatus(id.toString());
     } catch (Exception e) {
       LOG.error("Could not get status of workspace named: " + workspaceName);
       e.printStackTrace();
-      return false;
+      throw e;
+    }
+    if (!status.equals(actualStatus.toString())) {
+      throw new RuntimeException(
+          "The status of worksapce: "
+              + workspaceName
+              + " should be "
+              + status
+              + " but is "
+              + actualStatus);
     }
   }
 }

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/WorkspaceTest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/WorkspaceTest.java
@@ -14,6 +14,7 @@ package com.redhat.che.functional.tests;
 import com.google.inject.Inject;
 import com.redhat.che.selenium.core.client.RhCheTestWorkspaceServiceClient;
 import com.redhat.che.selenium.core.workspace.RhCheTestWorkspaceImpl;
+import java.util.concurrent.ExecutionException;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
 import org.slf4j.Logger;
@@ -23,11 +24,14 @@ import org.testng.annotations.Test;
 public class WorkspaceTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestTestClass.class);
+  // When creating workspace with che-starter, all others are stopped. Therefore it is better to
+  // start them in test - when both are created.
 
   @InjectTestWorkspace(startAfterCreation = false)
   private RhCheTestWorkspaceImpl workspaceToPass;
 
-  @Inject private RhCheTestWorkspaceImpl firstWorksapce;
+  @InjectTestWorkspace(startAfterCreation = false)
+  private RhCheTestWorkspaceImpl firstWorksapce;
 
   @Inject private RhCheTestWorkspaceServiceClient workspaceServiceClient;
 
@@ -35,6 +39,8 @@ public class WorkspaceTest {
   public void testCorrectWayOfStarting() throws Exception {
     String running = Workspaces.Status.RUNNING;
     String stopped = Workspaces.Status.STOPPED;
+
+    firstWorksapce.startWorkspace();
 
     firstWorksapce.checkStatus(running);
     workspaceToPass.checkStatus(stopped);
@@ -48,8 +54,8 @@ public class WorkspaceTest {
   }
 
   @Test
-  public void testWrongWayOfStarting() {
-    LOG.info("Try to start first one without PATCH.");
+  public void testWrongWayOfStarting() throws ExecutionException, InterruptedException {
+    LOG.info("Try to start " + firstWorksapce.getName() + " without PATCH.");
     try {
       workspaceServiceClient.startWithoutPatch(firstWorksapce.getId());
     } catch (Exception e) {

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/WorkspaceTest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/WorkspaceTest.java
@@ -32,7 +32,7 @@ public class WorkspaceTest {
   @Inject private RhCheTestWorkspaceServiceClient workspaceServiceClient;
 
   @Test
-  public void testCorrectWayOfStaring() throws Exception {
+  public void testCorrectWayOfStarting() throws Exception {
     String running = Workspaces.Status.RUNNING;
     String stopped = Workspaces.Status.STOPPED;
 


### PR DESCRIPTION
### What does this PR do?
Rh-che specific tests uses che-starter for handling workspaces. To be able to run upstream tests, it is needed to handle workspaces directly (without che-starter). This PR adopts upstream behaviour.

### How have you tested this PR?
localy