### PR TITLE
Adding 'org.eclipse.che.ls.java' to java based stacks

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -255,6 +255,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -329,6 +330,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.oc-login"
               ],
               "servers": {
@@ -410,6 +412,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -476,6 +479,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -629,6 +633,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java", 
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -705,6 +710,7 @@
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.exec",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -805,6 +811,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -895,6 +902,7 @@
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.exec",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp",
                 "com.redhat.oc-login"
               ],
@@ -1447,6 +1455,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "org.eclipse.che.ls.json"
               ]
             }
@@ -1560,6 +1569,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java",
                 "org.eclipse.che.ls.camel",
                 "com.redhat.oc-login"
               ],


### PR DESCRIPTION
### What does this PR do?
Adding 'org.eclipse.che.ls.java' to java based stacks since 6.13.0 is the first jdt.ls based stack and this installer must be presented in all the java based stacks - https://github.com/eclipse/che/pull/10863
### What issues does this PR fix or reference?

### How have you tested this PR?
Not tested. Manually enabling installer works fine on openshift.io