### PR TITLE
Don't use rh-nodejs4 - rh-nodejs8 is installed.

### DIFF
--- a/.ci/cico_rhche_compatibility_test.sh
+++ b/.ci/cico_rhche_compatibility_test.sh
@@ -5,6 +5,8 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
+set -e
+
 export USE_CHE_LATEST_SNAPSHOT="true"
 export BASEDIR=$(pwd)
 export DEV_CLUSTER_URL=https://devtools-dev.ext.devshift.net:8443/
@@ -34,7 +36,7 @@ export PROJECT_NAMESPACE=compatibility-check
 
 #change version of used che
 echo ">>> change upstream version to: $CHE_VERSION"
-scl enable rh-maven33 rh-nodejs4 "mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion=[${CHE_VERSION}] -U"
+scl enable rh-maven33 rh-nodejs8 "mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion=[${CHE_VERSION}] -U"
 
 echo "Running compatibility check with build, deploy to dev cluster and test."
 .ci/cico_build_deploy_test_rhche.sh


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Compatibility test was using rh-nodejs4, even though rh-nodejs8 was installed. This caused the command upgrading rh-che version to fail - job didn't fail though. That's why I also added `set -e`.