### PR TITLE
Updating rh-che to 6.13.1 upstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>6.13.0</version>
+        <version>6.13.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?
Updating rh-che to 6.13.1 upstream version

6.13.1 contains PVC cleanup fix & fix for improving IDE startup time - https://github.com/eclipse/che/issues/11860 
