### PR TITLE
rh-che #1075: Passing 'identity_id' to oso-proxy only via Impersonate-User Header

### DIFF
--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8WorkspaceEnvironmentProvider.java
@@ -118,7 +118,7 @@ public class Fabric8WorkspaceEnvironmentProvider {
 
     String userId = subject.getUserId();
     if (cheServiceAccountTokenToggle.useCheServiceAccountToken(userId)) {
-      String osoProxyUrl = multiClusterOpenShiftProxy.getUrlWithIdentityIdQueryParameter(userId);
+      String osoProxyUrl = multiClusterOpenShiftProxy.getUrl();
       LOG.debug("Using Che SA token for '{}'", userId);
       config =
           configBuilder.withMasterUrl(osoProxyUrl).withOauthToken(cheServiceAccountToken).build();


### PR DESCRIPTION
### What does this PR do?
Passing 'identity_id' to oso-proxy only via Impersonate-User Header

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1075
