### PR TITLE
Updating to upstream 6.14.2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>6.14.1</version>
+        <version>6.14.2</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?
Changes in 6.14.2 release:

Add property `che.workspace.server.ping_interval_milliseconds` to
control ping interval when checking that servers are running during
workspace start.

- https://github.com/eclipse/che/commit/f96c81f21745ed465e7fd3cea5db089f362c3265

Adding 'ImpersonatorInterceptor' during creation of KubernetesClient

- https://github.com/eclipse/che/commit/35faf112046a87c66792fa5a92d5df18e60ac64d


PR with changes - https://github.com/eclipse/che/pull/12034

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12035
