### PR TITLE
Remove guice-multibindings dependencies

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -41,10 +41,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.redhat.che</groupId>
             <artifactId>che-plugin-analytics-wsmaster</artifactId>
         </dependency>

--- a/plugins/che-plugin-bayesian-lang-server/pom.xml
+++ b/plugins/che-plugin-bayesian-lang-server/pom.xml
@@ -29,10 +29,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-languageserver</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>6.15.0</version>
+        <version>6.16.0-SNAPSHOT</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?
Follow up to dependecy upgrades in Che upstream
- removed `guice-multibindings` dependency, as it has become a part of guice core library

This PR should be merged only after the merge of respective PR in upstream https://github.com/eclipse/che-parent/pull/93

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11902

### How have you tested this PR?
none, building & ci test running should be done, as soon as master becomes compatible with upstream Che