### PR TITLE
rh-che #1116: Adding env var which allows to disable CORS

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -85,6 +85,11 @@ objects:
               configMapKeyRef:
                 key: che-jsonrpc-max-pool-size
                 name: rhche
+          - name: CHE_CORS_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                key: che-cors-enabled
+                name: rhche
           - name: CHE_DEBUG_SERVER
             valueFrom:
               configMapKeyRef:
@@ -357,6 +362,11 @@ objects:
             valueFrom:
               configMapKeyRef:
                 key: workspace-storage
+                name: rhche
+          - name: CHE_WSAGENT_CORS_ALLOWED__ORIGINS
+            valueFrom:
+              configMapKeyRef:
+                key: che-wsagent-cors-allowed-origins
                 name: rhche
           - name: JAVA_OPTS
             valueFrom:

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -15,6 +15,7 @@ data:
   analytics.woopra_domain: 'NULL'
   end2end-protect-verify-with-ip: "false"
   che-api: "https://che.prod-preview.openshift.io/api"
+  che-cors-enabled: "true"
   che-fabric8-auth-endpoint: "https://auth.prod-preview.openshift.io"
   che-fabric8-multicluster-oso-proxy-url: "https://osoproxy.prod-preview.openshift.io"
   che-fabric8-multitenant: "true"
@@ -40,6 +41,7 @@ data:
   che-system-admin-name: "admin"
   che-system-super-privileged-mode: "true"
   che-websocket-endpoint: "wss://che.prod-preview.openshift.io/api/websocket"
+  che-wsagent-cors-allowed-origins: "*"
   che.workspace.agent.dev.inactive_stop_timeout_ms: "900000"
   che-workspace-logs: "/workspace_logs"
   che-workspace-server-ping-interval-milliseconds: "500"
@@ -64,4 +66,3 @@ data:
   workspaces-memory-limit-max: "3gb"
   workspaces-pvc-storage-size: '1Gi'
   workspace-storage: "/home/user/che/workspaces"
-


### PR DESCRIPTION
The plan is the following:

- disable CORS on prod-preview, but not on prod
- test if everything works fine on prod-preview
- disable CORS  on prod

### What does this PR do?
Adding env var which allows to disable CORS

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1116

### HK issue
https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2470