### PR TITLE
Hotfix - remove keycloak token logic

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -8,7 +8,7 @@
 export PR_CHECK_BUILD="true"
 export BASEDIR=$(pwd)
 export DEV_CLUSTER_URL=https://devtools-dev.ext.devshift.net:8443/
-export OC_VERSION=3.9.33
+export OC_VERSION=3.10.85
 
 eval "$(./env-toolkit load -f jenkins-env.json -r \
         ^DEVSHIFT_TAG_LEN$ \

--- a/.ci/prepare_env_utils.sh
+++ b/.ci/prepare_env_utils.sh
@@ -52,12 +52,13 @@ function checkAllCreds() {
 	  CREDS_NOT_SET="true"
 	fi
 	
-	if [[ -z "${KEYCLOAK_TOKEN}" || -z "${RH_CHE_AUTOMATION_CHE_PREVIEW_USERNAME}" || -z "${RH_CHE_AUTOMATION_CHE_PREVIEW_PASSWORD}" ]]; then
+	if [[ -z "${RH_CHE_AUTOMATION_CHE_PREVIEW_USERNAME}" ]] ||
+	   [[ -z "${RH_CHE_AUTOMATION_CHE_PREVIEW_PASSWORD}" ]]; then
 	  echo "Prod-preview credentials not set."
 	  CREDS_NOT_SET="true"
 	fi
 	
-	if [ "${CREDS_NOT_SET}" = "true" ]; then
+	if [[ "${CREDS_NOT_SET}" = "true" ]]; then
 	  echo "Failed to parse jenkins secure store credentials"
 	  exit 2
 	else


### PR DESCRIPTION
### What does this PR do?
Keycloak token is not being used anymore - deleted from vault, removed keycloak token check logic
