### PR TITLE
WIP Updating rh-che RAM limit on prod / prod-preview to 5 GB

### DIFF
--- a/openshift/rh-che.app.yaml
+++ b/openshift/rh-che.app.yaml
@@ -426,7 +426,7 @@ objects:
             timeoutSeconds: 60
           resources:
             limits:
-              memory: 4Gi
+              memory: 5Gi
             requests:
               memory: 256Mi
         serviceAccountName: rhche


### PR DESCRIPTION
### What does this PR do?
Increasing RAM limit to 5Gb. Currently RAM calculation is the following:
there is a JVM option - `-XX:MaxRAMFraction=2` which means using 50% of the container RAM for heap
Also there is a `che-jsonrpc-max-pool-size` property which is in charge of the maximum size of the json rpc processing pool which is set to `2000`. 

Basically, current RAM consumption is the following:
- 4 GB for container
- 2 GB for heap
- 2 GB for off heap (1Mb for each of the 2000 threads created during json rpc processing)

However, there are also threads that need to be created by tomcat, which are not taken into account. Currently, QA team is planning to do investigation and empirically identify precise value for `che-jsonrpc-max-pool-size` for particular container RAM of che-server. As a temporary solution we want to increase RAM to 5GB for container:

- 2.5 for heap
- 2 for json rpc processing
- 0.5 for other (tomcat threads etc)  

Related issue for QA team - https://github.com/redhat-developer/che-functional-tests/issues/409