### PR TITLE
Removing offline tokens

### DIFF
--- a/dockerfiles/functional-tests/docker-entrypoint.sh
+++ b/dockerfiles/functional-tests/docker-entrypoint.sh
@@ -70,7 +70,6 @@ MVN_COMMAND="mvn clean --projects functional-tests -Pfunctional-tests -B \
   -Dche.testuser.password=${RHCHE_ACC_PASSWORD} \
   -Dche.host=${RHCHE_HOST_URL} \
   -Dche.osio.auth.endpoint=${CHE_OSIO_AUTH_ENDPOINT} \
-  -Dche.offline.to.access.token.exchange.endpoint=${RHCHE_OFFLINE_ACCESS_EXCHANGE} \
   -DexcludedGroups=${RHCHE_EXCLUDED_GROUPS} \
   -DcheStarterUrl=http://che-starter.localnetwork:10000 \
   -Dtests.screenshots_dir=${RHCHE_SCREENSHOTS_DIR} \

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -12,13 +12,12 @@ function printHelp {
 	GREEN="\\033[32;1m"
 	NC='\033[0m' # No Color
 	
-	echo -e "${YELLOW}$(basename "$0") ${WHITE}[-u <username>] [-p <passwd>] [-o <token>] [-m <email>] [-r <url>]" 
+	echo -e "${YELLOW}$(basename "$0") ${WHITE}[-u <username>] [-p <passwd>] [-m <email>] [-r <url>]" 
 	echo -e "\n${NC}Script for running functional tests against production or prod-preview environment."
 	echo -e "${GREEN}where:${WHITE}"
 	echo -e "-u    username for openshift account"
 	echo -e "-p    password for openshift account"
 	echo -e "-m    email for openshift account"
-	echo -e "-o    openshift offline token"
 	echo -e "-r    URL of Rh-che"
 	echo -e "${NC}All paramters are mandatory.\n"
 }
@@ -49,7 +48,7 @@ while getopts "hu:p:m:o:r:" opt; do
   esac
 done
 
-if [[ -z $USERNAME || -z $PASSWORD || -z $EMAIL || -z $OFFLINE_TOKEN || -z $HOST_URL ]]; then
+if [[ -z $USERNAME || -z $PASSWORD || -z $EMAIL || -z $HOST_URL ]]; then
 	echo "Please check if all credentials for user are set."
 	exit 1
 fi


### PR DESCRIPTION
### What does this PR do?
As far as tests are using CHE_INFRASTRUCTURE=OSIO no offline tokens are needed anymore.
All offline tokens appearances in scripts were removed. 
