### PR TITLE
Fix flaky test in AnalyticsManager

### DIFF
--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/main/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManager.java
@@ -359,7 +359,6 @@ public class AnalyticsManager {
     } catch (ExecutionException e) {
       LOG.warn("", e);
     }
-    ;
   }
 
   @VisibleForTesting

--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/test/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManagerTest.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsagent/src/test/java/com/redhat/che/plugin/analytics/wsagent/AnalyticsManagerTest.java
@@ -514,10 +514,21 @@ public class AnalyticsManagerTest {
     verify(analytics, timeout(AnalyticsManager.pingTimeout).atLeast(2))
         .enqueue(argCaptor.capture());
 
+    List<TrackMessage.Builder> stoppedEvents =
+        argCaptor
+            .getAllValues()
+            .stream()
+            .filter(ev -> ev.build().event().equals(WORKSPACE_STOPPED.toString()))
+            .collect(Collectors.toList());
+
     assertEquals(
-        capturedEventNames(argCaptor),
-        Arrays.asList(WORKSPACE_STARTED.toString(), WORKSPACE_STOPPED.toString()));
-    assertEquals(argCaptor.getAllValues().get(1).build().userId(), USER_ID);
+        stoppedEvents.size(),
+        1,
+        String.format("Workspace stop should send one %s event", WORKSPACE_STOPPED.toString()));
+    assertEquals(
+        stoppedEvents.iterator().next().build().userId(),
+        USER_ID,
+        "Stop event should have user id");
   }
 
   @Test


### PR DESCRIPTION
## Related issue 

https://github.com/redhat-developer/rh-che/issues/938

## What does this PR do?
Fixes a flaky test in `AnalyticsManager`. 

### What issues does this PR fix or reference?
Sometimes the `sendWorkspaceStoppedOnDestroy` test fails due to
```
java.lang.AssertionError: null: lists don't have the same size expected [2] but found [3]
	at com.redhat.che.plugin.analytics.wsagent.AnalyticsManagerTest.sendWorkspaceStoppedOnDestroy(AnalyticsManagerTest.java:517)
``` 

Instead we should check for the stop workspace event directly and verify that it is as expected.

I'm not sure why the test can fail (it only occasionally happens -- only reproduced the first time I ran the tests in Eclipse) but I'm guessing it's due to an inactivity event getting in the middle. FWIW I can cause the test to fail by stopping execution in debug before `destroy()` is called.

### How have you tested this PR?
Local build has worked for me, but the error was not consistent.