### PR TITLE
Dislabe check for che-starter as it should be deprecated.

### DIFF
--- a/functional-tests/src/test/resources/suites/prcheck.xml
+++ b/functional-tests/src/test/resources/suites/prcheck.xml
@@ -19,7 +19,6 @@
 
     <test name="all">
         <classes>
-            <class name="com.redhat.che.functional.tests.WorkspaceTest"/>
             <class name="com.redhat.che.functional.tests.BuildAndRunProjectTest"/>
         </classes>
     </test>

--- a/functional-tests/src/test/resources/suites/simpleTestSuite.xml
+++ b/functional-tests/src/test/resources/suites/simpleTestSuite.xml
@@ -20,7 +20,6 @@
     <test name="all">
         <classes>
             <class name="org.eclipse.che.selenium.miscellaneous.DialogAboutTest"/>
-            <class name="com.redhat.che.functional.tests.WorkspaceTest"/>
             <class name="com.redhat.che.functional.tests.BuildAndRunProjectTest"/>
         </classes>
     </test>


### PR DESCRIPTION
### What does this PR do?
Remove test for che-starter. It causes failures in periodic tests and it should be deprecated so it is not worth to fix that. 

