### PR TITLE
Updating rh-che version to che 7 beta 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>7.0.0-beta-1.0</version>
     <packaging>pom</packaging>
     <name>Fabric8 IDE</name>
     <inceptionYear>2016</inceptionYear>


### PR DESCRIPTION
### What does this PR do?
Maybe we should consider versioning of the rh-che due to https://github.com/eclipse/che/issues/12872

### What issues does this PR fix or reference?
looks like there were some versioning changes in the upstream and parent version is not exposed to the dashboard anymore 
![image](https://user-images.githubusercontent.com/1461122/54204866-74371300-44d5-11e9-9712-ef315f0861b8.png)

### How have you tested this PR?
Not tested 