### PR TITLE
Make workspace creation correctly propagate ephemeral mode status

### DIFF
--- a/assembly/fabric8-ide-dashboard-war/src/app/workspaces/create-workspace/create-workspace.controller.ts
+++ b/assembly/fabric8-ide-dashboard-war/src/app/workspaces/create-workspace/create-workspace.controller.ts
@@ -173,11 +173,13 @@ export class CreateWorkspaceController {
     this.hideLoader = false;
     this.displayPlugins = false;
 
+    /** Begin rhche specific changes */
     if (!this.workspaceConfig || !this.workspaceConfig.attributes || !this.workspaceConfig.persistVolumes) {
-      this.isEphemeralMode = true;
+      this.isEphemeralMode = false;
     } else {
       this.isEphemeralMode = JSON.parse(this.workspaceConfig.attributes.persistVolumes);
     }
+    /** End rhche specific changes */
 
     // header toolbar
     // dropdown button config
@@ -237,6 +239,12 @@ export class CreateWorkspaceController {
       this.stackMachines = [];
       return;
     }
+
+    /** Begin rhche specific changes */
+    // Set persistVolumes: false (ephemeral mode)
+    this.isEphemeralMode = true;
+    this.onEphemeralModeChange();
+    /** End rhche specific changes */
 
     const environmentName = this.stack.workspaceConfig.defaultEnv;
     const environment = this.stack.workspaceConfig.environments[environmentName];


### PR DESCRIPTION
### What does this PR do?
Make created workspaces ephemeral by default.

Previously, although ephemeral toggle was set to `enabled` by default, this setting would not be propagated into the workspace config unless it was toggled during creation.

### What issues does this PR fix or reference?
#1263, related PR #1276

### How have you tested this PR?
Locally on minishift (ephemeral mode works now without having to disable and reenable toggle)