### PR TITLE
Added dockerfile for load-tests image

### DIFF
--- a/dockerfiles/load-tests/Dockerfile
+++ b/dockerfiles/load-tests/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright (c) 2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+FROM library/centos:centos7
+
+EXPOSE 8089
+
+RUN yum update --assumeyes \
+ && yum install --assumeyes \
+    git \
+    gcc \
+    make \
+    openssl-devel \
+    bzip2-devel \
+    libffi-devel
+
+WORKDIR /usr/src/
+RUN curl https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz --output Python-3.7.2.tgz && tar xzf Python-3.7.2.tgz \
+ && cd Python-3.7.2 && ./configure --enable-optimizations && make altinstall && make clean \
+ && python3.7 -m pip install locustio locust websocket-client python-dateutil
+
+WORKDIR /
+RUN git clone --single-branch --branch=master https://github.com/redhat-developer/rh-che.git rh-che-loadtesting
+WORKDIR /rh-che-loadtesting/load-tests
+COPY entrypoint.sh entrypoint.sh
+ENTRYPOINT ["/rh-che-loadtesting/load-tests/entrypoint.sh"]

--- a/dockerfiles/load-tests/entrypoint.sh
+++ b/dockerfiles/load-tests/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export LOCUST_RHCHE_PROTOCOL=${PROTOCOL}
+export LOCUST_RHCHE_BASE_URI=${BASEURL}
+export LOCUST_RHCHE_ACTIVE_TOKEN=${TOKEN}
+
+locust -f real-life.py

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -22,6 +22,16 @@ LOCUST_RHCHE_BASE_URI="rhche-rhche.192.168.99.100.nip.io" \
 locust -f simple.py
 ```
 
+Alternatively you can use docker to run these tests with all the dependencies pre-packaged inside:
+
+```{allowEmpty=true}
+docker run -p 8089:8089 \
+-e "TOKEN=<active_token>" \
+-e "BASEURL=rhche-rhche.192.168.99.100.nip.io" \
+-e "PROTOCOL=<http|https>" \
+quay.io/tdancs/rhche-locust-load-tests
+```
+
 This should launch a local locust instance on your host machine.
 You should be able to open your browser and go to <http://127.0.0.1:8089/>
 


### PR DESCRIPTION
### What does this PR do?
This PR adds an ability to run the locust based load tests from within a docker image.
Easy to use, no configuration needed.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/449

### How have you tested this PR?
Manually tested against my stresstesting deployment on devshift-dev