### PR TITLE
Remove workaround

### DIFF
--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianAbstractTestClass.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianAbstractTestClass.java
@@ -83,9 +83,6 @@ public abstract class BayesianAbstractTestClass extends RhCheAbstractTestClass {
   public void openTestFile() throws Exception {
     LOG.info("Waiting for workspace to be ready.");
     checkWorkspace(workspace);
-    LOG.info("Waiting for project to be imported.");
-    importWorkaround(workspace, 5);
-    LOG.info("Project imported, running tests.");
   }
 
   @BeforeMethod

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BuildAndRunProjectTest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BuildAndRunProjectTest.java
@@ -16,7 +16,6 @@ import com.redhat.che.selenium.core.workspace.RhCheWorkspaceTemplate;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,14 +29,12 @@ public class BuildAndRunProjectTest extends RhCheAbstractTestClass {
   @InjectTestWorkspace(template = RhCheWorkspaceTemplate.RH_VERTX)
   private TestWorkspace workspace;
 
-  @Inject private ProjectExplorer projectExplorer;
   @Inject private CommandsPalette commandsPalette;
   @Inject private Consoles consoles;
 
   @BeforeClass
   public void checkWorkspace() throws Exception {
     checkWorkspace(workspace);
-    importWorkaround(workspace, 5);
   }
 
   @Test

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BuildAndRunProjectTest.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BuildAndRunProjectTest.java
@@ -16,6 +16,7 @@ import com.redhat.che.selenium.core.workspace.RhCheWorkspaceTemplate;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ public class BuildAndRunProjectTest extends RhCheAbstractTestClass {
   @InjectTestWorkspace(template = RhCheWorkspaceTemplate.RH_VERTX)
   private TestWorkspace workspace;
 
+  @Inject private ProjectExplorer projectExplorer;
   @Inject private CommandsPalette commandsPalette;
   @Inject private Consoles consoles;
 

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/RhCheAbstractTestClass.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/RhCheAbstractTestClass.java
@@ -45,6 +45,7 @@ public abstract class RhCheAbstractTestClass {
       ide.waitOpenedWorkspaceIsReadyToUse();
       projectExplorer.waitProjectExplorer();
       notificationsPopupPanel.waitProgressPopupPanelClose();
+      checkProjectPresent(workspace);
     } catch (ExecutionException | InterruptedException e) {
       LOG.error(
           "Could not obtain workspace name and id - worskape was probably not successfully injected.");
@@ -59,25 +60,11 @@ public abstract class RhCheAbstractTestClass {
     }
   }
 
-  // This method is a workaround for issue:
-  // https://github.com/openshiftio/openshift.io/issues/4695
-  // If project is not imported, refresh whole page. Try for <maxTires> attempts.
-  public void importWorkaround(TestWorkspace workspace, int maxTries) throws Exception {
-    int counter = 0;
-
-    while (projectExplorer.getNamesOfAllOpenItems().get(0).equals("There are no projects")) {
-      counter++;
-      LOG.warn(
-          "Project was not imported. Trying to refresh the page to import the project. Attempt {}/5",
-          counter);
-      seleniumWebDriver.get(seleniumWebDriver.getCurrentUrl());
-      checkWorkspace(workspace);
-      if (counter == maxTries) {
-        LOG.error("Project was not imported in " + maxTries + " tries.");
-        throw new RuntimeException("Project was not imported to the workspace.");
-      }
+  public void checkProjectPresent(TestWorkspace workspace) throws Exception {
+    if (projectExplorer.getNamesOfAllOpenItems().get(0).equals("There are no projects")) {
+      LOG.error("Project was not imported.");
+      throw new RuntimeException("Project was not imported to the workspace.");
     }
-    LOG.info(String.format("Project successfully imported after %d attempts.", counter + 1));
   }
 
   public void closeFilesAndProject() {


### PR DESCRIPTION
### What does this PR do?
There was an issue due to instable infra, that sometimes project was not imported. The workaround for this was refreshing the page. As far as issue was fixed, the workaround is not needed. 
Changing the logic of workaround to simple check if project is present. 

### What issues does this PR fix or reference?


### How have you tested this PR?
localy against prod-preview