### PR TITLE
Remove yarn.lock workaround in dashboard build.

### DIFF
--- a/assembly/fabric8-ide-dashboard-war/Dockerfile
+++ b/assembly/fabric8-ide-dashboard-war/Dockerfile
@@ -15,7 +15,6 @@
 FROM node:8.15.1
 
 ARG SOURCES_DIR
-ARG UPSTREAM_VERSION
 
 RUN apt-get update && \
     apt-get install -y git \
@@ -24,7 +23,6 @@ RUN apt-get update && \
 RUN yarn global upgrade yarn@1.13.0
 # Copy only necessary files and run yarn with them to allow caching in case dependencies hasn't changed
 COPY ["${SOURCES_DIR}/package.json", "${SOURCES_DIR}/typings.json", "/dashboard/"]
-RUN wget https://raw.githubusercontent.com/eclipse/che/${UPSTREAM_VERSION}/dashboard/yarn.lock -P /dashboard/
 WORKDIR /dashboard
 RUN yarn install --ignore-optional --ignore-scripts
 # Copy all the files (including previously copied) for simplicity of the Dockerfile

--- a/assembly/fabric8-ide-dashboard-war/pom.xml
+++ b/assembly/fabric8-ide-dashboard-war/pom.xml
@@ -157,8 +157,6 @@
                                             <arg value="eclipse-che-dashboard" />
                                             <arg value="--build-arg" />
                                             <arg value="SOURCES_DIR=./target/sources" />
-                                            <arg value="--build-arg" />
-                                            <arg value="UPSTREAM_VERSION=${che.version}" />
                                             <arg value="." />
                                         </exec>
                                     </target>
@@ -213,21 +211,6 @@
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
-                            <!-- Get upstream yarn.lock file -->
-                            <execution>
-                                <id>get-yarn-lock</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <exec dir="${basedir}/target/sources" executable="wget" failonerror="true">
-                                            <arg value="https://raw.githubusercontent.com/eclipse/che/${che.version}/dashboard/yarn.lock"/>
-                                        </exec>
-                                    </target>
-                                </configuration>
-                            </execution>
                             <!-- Use yarn to get dependencies -->
                             <execution>
                                 <id>install-yarn</id>


### PR DESCRIPTION
### What does this PR do?
Removes downloading upstream yarn.lock from dashboard build process.

Depends on a version of Che that contains https://github.com/eclipse/che/pull/13162. Draft PR until we move to next upstream release.

Do not merge until https://github.com/redhat-developer/rh-che/issues/1375 is resolved.