### PR TITLE
Update to upstream 7.0.0-beta-4.0

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/rh-che.properties
@@ -44,8 +44,8 @@ che.fabric8.end2end.protect.verify_with_ip=false
 
 # Full identifier of the default editor whose CDN resources
 # should be prefetched during the dashboard client-side load 
-# - Can be the identifier of an editor plugin in the plugin registry, like that:
-#     org.eclipse.che.editor.theia:1.0.0
-# - or the full path to a custom editor plugin, like that:
-#     https://raw.githubusercontent.com/davidfestal/che-theia-cdn/master/plugins/org.eclipse.che.editor.theia.david:1.0.2
+# - Can be the identifier of an editor plugin in the plugin registry:
+#     eclipse/che-theia/1.0.0
+# - or the full path to a custom editor plugin (following the spec used in upstream):
+#     https://raw.githubusercontent.com/davidfestal/che-theia-cdn/master/plugins/eclipse/che-theia/1.0.0
 che.fabric8.cdn.prefetch.editor=NULL

--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -228,8 +228,8 @@
       },
       "projects": [],
       "attributes": {
-        "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-machine-exec-plugin:0.0.1"
+        "editor": "eclipse/che-theia/1.0.0",
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
       },
       "commands": [
         {
@@ -308,8 +308,8 @@
       },
       "projects": [],
       "attributes": {
-        "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-machine-exec-plugin:0.0.1"
+        "editor": "eclipse/che-theia/1.0.0",
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
       },
       "commands": [
         {

--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -57,7 +57,7 @@ data:
   CHE_LOG_LEVEL: "INFO"
   CHE_LOGS_APPENDERS_IMPL: "json"
   CHE_MULTIUSER: "true"
-  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: 'https://che-plugin-registry.prod-preview.openshift.io/'
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: 'https://che-plugin-registry.prod-preview.openshift.io/v2'
   CHE_PORT: "8080"
   CHE_DEBUG_SERVER: "false"
   SENTRY_ENVIRONMENT: 'dev'

--- a/plugins/fabric8-cdn-support/pom.xml
+++ b/plugins/fabric8-cdn-support/pom.xml
@@ -61,10 +61,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-workspace-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/fabric8-cdn-support/src/main/java/com/redhat/che/cdn/HttpYamlDownloader.java
+++ b/plugins/fabric8-cdn-support/src/main/java/com/redhat/che/cdn/HttpYamlDownloader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.redhat.che.cdn;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+
+public class HttpYamlDownloader {
+  private static final ObjectMapper YAML_PARSER = new ObjectMapper(new YAMLFactory());
+
+  public PluginMeta getYamlResponseAndParse(URI uri) throws IOException {
+    HttpURLConnection httpURLConnection = null;
+    try {
+      httpURLConnection = (HttpURLConnection) uri.toURL().openConnection();
+      if (httpURLConnection.getResponseCode() != 200) {
+        throw new IOException(
+            String.format(
+                "Could not get editor meta from URI '%s': Error: '%s'",
+                uri, getError(httpURLConnection)));
+      }
+
+      return parseYamlResponseStreamAndClose(httpURLConnection.getInputStream());
+    } finally {
+      if (httpURLConnection != null) {
+        httpURLConnection.disconnect();
+      }
+    }
+  }
+
+  private String getError(HttpURLConnection httpURLConnection) throws IOException {
+    try (InputStreamReader isr = new InputStreamReader(httpURLConnection.getInputStream())) {
+      return CharStreams.toString(isr);
+    }
+  }
+
+  protected PluginMeta parseYamlResponseStreamAndClose(InputStream inputStream) throws IOException {
+    try (InputStreamReader reader = new InputStreamReader(inputStream)) {
+      return YAML_PARSER.readValue(reader, PluginMeta.class);
+    } catch (IOException e) {
+      throw new IOException(
+          "Internal server error. Unexpected response body received from Che plugin registry API."
+              + e.getLocalizedMessage(),
+          e);
+    }
+  }
+}

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OpenShiftProjectFactory.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/Fabric8OpenShiftProjectFactory.java
@@ -32,7 +32,7 @@ public class Fabric8OpenShiftProjectFactory extends OpenShiftProjectFactory {
       @Nullable @Named("che.infra.openshift.project") String projectName,
       OpenShiftClientFactory clientFactory,
       Fabric8WorkspaceEnvironmentProvider envProvider) {
-    super(projectName, null, clientFactory);
+    super(projectName, null, null, clientFactory);
     this.clientFactory = clientFactory;
     this.envProvider = envProvider;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.0.0-beta-3.0</version>
+        <version>7.0.0-beta-4.0</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>


### PR DESCRIPTION
### What does this PR do?
Update to upstream Che `7.0.0-beta-4.0`.

The upstream changes between beta 3.0 and 4.0 remove `PluginMetaRetriever` in favor of using the plugin broker for both downloading metas and artifacts. `CdnSupportService` has to be updated to reflect these changes, so this PR moves some of the old `PluginMetaRetriever` functionality into this repo (downloading and parsing `meta.yaml`s). I haven't been able to thoroughly test this functionality yet.

### What issues does this PR fix or reference?
#1375 
