### PR TITLE
Update default Theia IDE version to 'next' for Che 7 stacks

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -228,7 +228,7 @@
       },
       "projects": [],
       "attributes": {
-        "editor": "eclipse/che-theia/1.0.0",
+        "editor": "eclipse/che-theia/next",
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
       },
       "commands": [
@@ -308,7 +308,7 @@
       },
       "projects": [],
       "attributes": {
-        "editor": "eclipse/che-theia/1.0.0",
+        "editor": "eclipse/che-theia/next",
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
       },
       "commands": [


### PR DESCRIPTION

### What does this PR do?
Update default Theia IDE version to 'next' for Che 7 stacks

### What issues does this PR fix or reference?
related to - https://github.com/redhat-developer/rh-che/issues/1347
Also to the upstream PR - https://github.com/eclipse/che/pull/13235

### How have you tested this PR?
on che.openshift.io
