### PR TITLE
rh-che #1347 Adding Che 7 java-maven upstream stack

### DIFF
--- a/assembly/fabric8-stacks/src/main/resources/stacks.json
+++ b/assembly/fabric8-stacks/src/main/resources/stacks.json
@@ -327,6 +327,90 @@
     }
   },
   {
+    "id": "java-maven",
+    "creator": "ide",
+    "name": "Java Maven",
+    "description": "Default Java Stack with OpenJDK 11 and Maven 3.6",
+    "scope": "general",
+    "tags": [
+      "Java",
+      "OpenJDK",
+      "Maven",
+      "Spring Boot v2",
+      "Vert.x",
+      "Debian"
+    ],
+    "components": [
+      {
+        "name": "Debian",
+        "version": "9.8"
+      },
+      {
+        "name": "OpenJDK",
+        "version": "11.0.2"
+      },
+      {
+        "name": "Maven",
+        "version": "3.6.0"
+      }
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "maven-container": {
+              "servers": {
+                "8080/tcp": {
+                  "port": "8080",
+                  "protocol": "http"
+                }
+              },
+              "attributes": {
+                "memoryLimitBytes": "512000000",
+                "containerCommand": "['sleep']",
+                "containerArgs": "['infinity']"
+              },
+              "volumes": {
+                "m2": {
+                  "path": "/home/user/.m2"
+                },
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "env": {
+                "MAVEN_CONFIG": "/home/user/.m2",
+                "MAVEN_OPTS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "JAVA_OPTS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "JAVA_TOOL_OPTIONS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "PS1": "$(echo ${0})\\$ ",
+                "HOME": "/home/user"
+              }
+            }
+          },
+          "recipe": {
+            "content": "maven:3.6.0-jdk-11",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "attributes": {
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1,redhat/java/0.38.0",
+        "editor": "eclipse/che-theia/next",
+        "sidecar.redhat/java.memory_limit": "1500Mi",
+        "sidecar.eclipse/che-theia.memory_limit": "512Mi"
+      },
+      "commands": []
+    },
+    "stackIcon": {
+      "name": "type-che7.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
     "id": "openshift-sql",
     "name": "Java + MySQL DB",
     "description": "Multi Container Workspace: Java + MySQL",


### PR DESCRIPTION
### What does this PR do?
Adding Che 7 java-maven upstream stack

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1347

### How have you tested this PR?
Tested on che.openshift.io
Basic example console java example works just fine.
However, having problems with running `vertx-http-booster`
"Build" command works just fine, but "Run" command fails with the following error and preview URL is not working correctly:

> [INFO] SEVERE: Failed to create the vert.x instance
> [INFO] java.lang.IllegalStateException: Failed to create cache dir
> [INFO]  at io.vertx.core.file.impl.FileResolver.setupCacheDir(FileResolver.java:333)
> [INFO]  at io.vertx.core.file.impl.FileResolver.<init>(FileResolver.java:88)
> [INFO]  at io.vertx.core.impl.VertxImpl.<init>(VertxImpl.java:168)
> [INFO]  at io.vertx.core.impl.VertxImpl.vertx(VertxImpl.java:93)
> [INFO]  at io.vertx.core.impl.VertxFactoryImpl.vertx(VertxFactoryImpl.java:38)
> [INFO]  at io.vertx.core.Vertx.vertx(Vertx.java:85)
> [INFO]  at io.vertx.core.impl.launcher.commands.ClasspathHandler.create(ClasspathHandler.java:113)
> [INFO]  at io.vertx.core.impl.launcher.commands.BareCommand.startVertx(BareCommand.java:276)
> [INFO]  at io.vertx.core.impl.launcher.commands.BareCommand.run(BareCommand.java:191)
> [INFO]  at io.vertx.core.impl.launcher.commands.RunCommand.run(RunCommand.java:249)
> [INFO]  at io.vertx.core.impl.launcher.VertxCommandLauncher.execute(VertxCommandLauncher.java:226)
> [INFO]  at io.vertx.core.impl.launcher.VertxCommandLauncher.dispatch(VertxCommandLauncher.java:361)
> [INFO]  at io.vertx.core.impl.launcher.VertxCommandLauncher.dispatch(VertxCommandLauncher.java:324)
> [INFO]  at io.vertx.core.Launcher.main(Launcher.java:45)

Looks like the community image is not fully compatible with OpenShift. 