### PR TITLE
Adding devfile registry env var to the cm

### DIFF
--- a/openshift/rh-che.config.yaml
+++ b/openshift/rh-che.config.yaml
@@ -58,6 +58,7 @@ data:
   CHE_LOGS_APPENDERS_IMPL: "json"
   CHE_MULTIUSER: "true"
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: 'https://che-plugin-registry.prod-preview.openshift.io/v3'
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: 'https://che-devfile-registry.prod-preview.openshift.io/'
   CHE_PORT: "8080"
   CHE_DEBUG_SERVER: "false"
   SENTRY_ENVIRONMENT: 'dev'


### PR DESCRIPTION
### What does this PR do?
Adding devfile registry env var to the cm
Related to https://gitlab.cee.redhat.com/service/app-interface/merge_requests/652/
devfile registry will be used only once rhche is updated to CR1 version - https://github.com/redhat-developer/rh-che/issues/1412

### What issues does this PR fix or reference?
N/A 
related to  https://github.com/redhat-developer/rh-che/issues/1412

### How have you tested this PR?
N/A