### PR TITLE
Add time info to running periodic tests.

### DIFF
--- a/.ci/cico_build_deploy_test_rhche.sh
+++ b/.ci/cico_build_deploy_test_rhche.sh
@@ -41,7 +41,7 @@ fi
 start=$(date +%s)
 BuildTagAndPushDocker
 stop=$(date +%s)
-build_tag_push_duration=$(echo "$stop - $start" | bc)
+build_tag_push_duration=$(($stop - $start))
 echo "Build, tag and push lasted $build_tag_push_duration seconds."
 
 
@@ -76,7 +76,7 @@ fi
 set -x
 
 stop=$(date +%s)
-deploy_duration=$(echo "$stop - $start" | bc)
+deploy_duration=$(($stop - $start))
 echo "Deploy on devcluster lasted $deploy_duration seconds."
 
 start=$(date +%s)
@@ -89,7 +89,7 @@ else
   exit 4
 fi
 stop=$(date +%s)
-test_duration=$(echo "$stop - $start" | bc)
+test_duration=$(($stop - $start))
 echo "Test execution lasted $test_duration seconds."
 
 unset RH_CHE_AUTOMATION_BUILD_TAG;

--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -30,7 +30,7 @@ echo "Installing dependencies:"
 start=$(date +%s)
 installDependencies
 stop=$(date +%s)
-instal_dep_duration=$(echo "$stop - $start" | bc)
+instal_dep_duration=$(($stop - $start))
 echo "Installing all dependencies lasted $instal_dep_duration seconds."
 
 export PROJECT_NAMESPACE=prcheck-${RH_PULL_REQUEST_ID}
@@ -40,5 +40,5 @@ echo "Running ${JOB_NAME} PR: #${RH_PULL_REQUEST_ID}, build number #${BUILD_NUMB
 .ci/cico_build_deploy_test_rhche.sh
 
 end_time=$(date +%s)
-whole_check_duration=$(echo "$end_time - $total_start_time" | bc)
+whole_check_duration=$(($end_time - $total_start_time))
 echo "****** PR check ended at $(date) and whole run took $whole_check_duration seconds. ******"

--- a/.ci/functional_tests_utils.sh
+++ b/.ci/functional_tests_utils.sh
@@ -40,17 +40,12 @@ function installNodejs() {
 	yum install --assumeyes rh-nodejs8
 }
 
-function installBC(){
-	yum install --assumeyes bc
-}
-
 function installDependencies() {
 	installEpelRelease
 	installYQ
 	installStartDocker
 	installJQ
 	installOC
-	installBC
 	
 	# Getting dependencies ready
 	yum install --assumeyes \

--- a/functional-tests/devscripts/prepare_env.sh
+++ b/functional-tests/devscripts/prepare_env.sh
@@ -7,7 +7,6 @@ echo "Installing dependencies..."
 
 source .ci/functional_tests_utils.sh
 installJQ
-installBC
 installStartDocker
 
 docker pull quay.io/openshiftio/rhchestage-rh-che-functional-tests-dep | cat # Suppress multiple-line output for docker pull
@@ -18,5 +17,5 @@ eval "$(./env-toolkit load -f jenkins-env.json -r  USERNAME PASSWORD EMAIL OFFLI
 mkdir logs
 
 end=$(date +%s)
-instal_deps_duration=$(echo "$end - $start" | bc)
+instal_deps_duration=$(($end - $start))
 echo "Installing dependencies lasted $instal_deps_duration seconds."

--- a/functional-tests/devscripts/prepare_env.sh
+++ b/functional-tests/devscripts/prepare_env.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
-
+echo "***** Installing dependencies for functional tests $(date) ******"
+start=$(date +%s)
 set -e
 echo "Installing docker..."
 yum install -y docker | cat # Suppress multiple-line output for package installation
+yum install --assumeyes bc
+yum install epel-release --assumeyes
+yum update --assumeyes
+yum install --assumeyes -q jq
+
 systemctl start docker
 docker pull quay.io/openshiftio/rhchestage-rh-che-functional-tests-dep | cat # Suppress multiple-line output for docker pull
 
@@ -11,3 +17,6 @@ eval "$(./env-toolkit load -f jenkins-env.json -r  USERNAME PASSWORD EMAIL OFFLI
 
 mkdir logs
 
+end=$(date +%s)
+instal_deps_duration=$(echo "$end - $start" | bc)
+echo "Installing dependencies lasted $instal_deps_duration seconds."

--- a/functional-tests/devscripts/prepare_env.sh
+++ b/functional-tests/devscripts/prepare_env.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 echo "***** Installing dependencies for functional tests $(date) ******"
+
 start=$(date +%s)
 set -e
-echo "Installing docker..."
-yum install -y docker | cat # Suppress multiple-line output for package installation
-yum install --assumeyes bc
-yum install epel-release --assumeyes
-yum update --assumeyes
-yum install --assumeyes -q jq
+echo "Installing dependencies..."
 
-systemctl start docker
+source .ci/functional_tests_utils.sh
+installJQ
+installBC
+installStartDocker
+
 docker pull quay.io/openshiftio/rhchestage-rh-che-functional-tests-dep | cat # Suppress multiple-line output for docker pull
 
 export HOST_URL=$HOST_URL

--- a/functional-tests/devscripts/route_tests.sh
+++ b/functional-tests/devscripts/route_tests.sh
@@ -43,9 +43,7 @@ function checkPrereq {
 		fi
 		installOC
 	fi
-	
-	yum install -y bc
-	
+		
 	if $SEND_TO_ZABBIX; then
 		rpm -ivh https://repo.zabbix.com/zabbix/3.0/rhel/7/x86_64/zabbix-release-3.0-1.el7.noarch.rpm
 		yum install -y zabbix-sender
@@ -142,7 +140,7 @@ ZABBIX_TIMESTAMP=$(date +%s) # time when test starts
 start_time=$(date +%s.%N)
 wait_for_route
 end_time=$(date +%s.%N)
-exposure_time=$(echo "$end_time - $start_time" | bc)
+exposure_time=$(($end_time - $start_time))
 
 if ! $hard_failed; then
 	printf "Time taken for route to be available: %.3f seconds. \n" $exposure_time

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -159,13 +159,13 @@ else
 fi
 
 end=$(date +%s)
-test_duration=$(echo "$end - $start" | bc)
+test_duration=$(($end - $start))
 echo "Running tests lasted $test_duration seconds."
 
 start=$(date +%s)
 archiveArtifacts
 end=$(date +%s)
-archive_duration=$(echo "$end - $start" | bc)
+archive_duration=$(($end - $start))
 echo "Archiving artifacts lasted $archive_duration seconds."
 
 if [[ $RESULT == 0 ]]; then

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -4,7 +4,11 @@
 #   checkAllCreds
 #   installDependencies
 #   archiveArtifacts
+
 source .ci/functional_tests_utils.sh
+
+echo "****** Starting functional tests $(date) ******"
+start=$(date +%s)
 
 function printHelp {
 	YELLOW="\\033[93;1m"
@@ -154,7 +158,15 @@ else
 	fi
 fi
 
+end=$(date +%s)
+test_duration=$(echo "$end - $start" | bc)
+echo "Running tests lasted $test_duration seconds."
+
+start=$(date +%s)
 archiveArtifacts
+end=$(date +%s)
+archive_duration=$(echo "$end - $start" | bc)
+echo "Archiving artifacts lasted $archive_duration seconds."
 
 if [[ $RESULT == 0 ]]; then
 	echo "Tests result: SUCCESS"


### PR DESCRIPTION
### What does this PR do?
According to BUILD TIMEOUT that happens from time to time on periodic tests, it would be nice to gather more info from those tests. Currently it has timeout set to 60 minutes, but tests seem to last only 9 minutes. The rest of a time seems to be spent on installing docker, pulling image and other stuff.

Job I'm reffering to: https://ci.centos.org/job/devtools-rh-che-periodic-prod-2/863/console

