### PR TITLE
Add script to check for upstream dashboard changes when updating version

### DIFF
--- a/dev-scripts/check-upstream-dashboard.sh
+++ b/dev-scripts/check-upstream-dashboard.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+RED="\e[31m"
+GREEN="\e[32m"
+RESET="\e[39m"
+
+function generate_diff() {
+  mvn -q clean dependency:unpack-dependencies@extract-upstream-sources antrun:run@diff-source-trees -pl ':fabric8-ide-dashboard-war'
+}
+
+function check_for_changes() {
+  CUR=$(grep -v -e "^Only in" -e "\+\+\+" -e "---" tmp/current.diff)
+  NEW=$(grep -v -e "^Only in" -e "\+\+\+" -e "---" tmp/new.diff)
+  diff <(echo "$CUR") <(echo "$NEW") > /dev/null
+}
+
+function print_changed_files() {
+  if command -v interdiff > /dev/null; then
+    echo -e "$RED"
+    interdiff tmp/current.diff tmp/new.diff | grep diff | cut -f 4 -d ' '
+    echo -e "$RESET"
+  else
+    echo "Printing changed files depends on program 'interdiff'"
+  fi
+}
+
+function cleanup() {
+  echo "Executing cleanup"
+  git checkout -- .
+  rm -rf ./tmp
+}
+
+if ! git diff-index --quiet HEAD --; then
+  echo "Git repository has uncommitted changes. Aborting"
+  exit 1
+fi
+
+trap cleanup EXIT
+
+NEW_VER=$1
+if [ -z "$NEW_VER" ]; then
+  echo "Usage: check_dashboard.sh \$NEW_VERSION"
+  exit 1
+fi
+
+echo "Testing update to version ${NEW_VER}"
+mkdir -p tmp
+
+# Get current diff against upstream source tree
+echo "Getting dashboard source diff for current Che parent version"
+generate_diff
+cp assembly/fabric8-ide-dashboard-war/target/src_tree.diff tmp/current.diff
+
+# Update project parent to new version
+echo "Updating parent version in pom.xml to ${NEW_VER}"
+NEW_POM=$(xq --arg VER "$NEW_VER" '.project.parent.version = $VER' pom.xml -x)
+echo "${NEW_POM}" > pom.xml
+
+# Get diff for updated parent version
+echo "Getting dashboard source diff for Che parent version ${NEW_VER}"
+generate_diff
+cp assembly/fabric8-ide-dashboard-war/target/src_tree.diff tmp/new.diff
+
+if ! check_for_changes; then
+  echo -e "${RED}Upstream changes detected. Changed files:${RESET}"
+  print_changed_files
+else
+  echo -e "${GREEN}No upstream changes detected.${RESET}"
+fi
+


### PR DESCRIPTION
### What does this PR do?
Add script `./dev-scripts/check-upstream-dashboard.sh`, to be used when updating the Che parent version. The script compares downstream dashboard changes between the current version and a new specified version and lists files that need to be updated in this repository.

#### Usage:

`./dev-scripts/check-upstream-dashboard.sh <NEW_VERSION>`

#### Depends on:

- xq (installed alongside yq automatically)
- interdiff (from patchutils; used for getting list of files to be updated)

#### Example output:
```
$ ./dev-scripts/check-upstream-dashboard.sh "7.0.0-RC-2.0-SNAPSHOT"
Testing update to version 7.0.0-RC-2.0-SNAPSHOT
Getting dashboard source diff for current Che parent version
     [exec] Result: 1
Updating parent version in pom.xml to 7.0.0-RC-2.0-SNAPSHOT
Getting dashboard source diff for Che parent version 7.0.0-RC-2.0-SNAPSHOT
     [exec] Result: 1
Upstream changes detected. Changed files:

/home/amisevsk/git/rh-che/assembly/fabric8-ide-dashboard-war/target/sources/src/app/workspaces/create-workspace/create-workspace.controller.ts
/home/amisevsk/git/rh-che/assembly/fabric8-ide-dashboard-war/target/sources/src/app/workspaces/create-workspace/create-workspace.html

Executing cleanup
```

### What issues does this PR fix or reference?
It is useful whenever we update to a new Che parent version; compare output of script above against commit https://github.com/redhat-developer/rh-che/pull/1445/commits/6f140ed5e9f7129b12917d3f2480eb80521709f7

### How have you tested this PR?
Manually, testing both situations where updates are needed (`7.0.0-RC-1.0 -> 7.0.0-RC-2.0`) and where no changes are necessary (`6.18.0 -> 6.18.1`).