### PR TITLE
Enabled selenium tests to use old stack-based approach

### DIFF
--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianAbstractTestClass.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianAbstractTestClass.java
@@ -12,7 +12,6 @@
 package com.redhat.che.functional.tests;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -34,10 +33,6 @@ public abstract class BayesianAbstractTestClass extends RhCheAbstractTestClass {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private TestApiEndpointUrlProvider testApiEndpointUrlProvider;
 
-  @Inject
-  @Named("che.host")
-  String cheHost;
-
   private Integer EXPECTED_ERROR_LINE;
   private Integer INJECTION_ENTRY_POINT;
   private String EXPECTED_ERROR_TEXT;
@@ -45,8 +40,6 @@ public abstract class BayesianAbstractTestClass extends RhCheAbstractTestClass {
   private String PATH_TO_FILE;
   private String PROJECT_DEPENDENCY;
   private String ERROR_MESSAGE;
-  public static final String CHE_PROD_PREVIEW_URL = "che.prod-preview.openshift.io";
-  public static final String CHE_PROD_URL = "che.openshift.io";
 
   public void setExpectedErrorLine(Integer expectedErrorLine) {
     EXPECTED_ERROR_LINE = expectedErrorLine;

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianPackageJson.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianPackageJson.java
@@ -36,7 +36,7 @@ public class BayesianPackageJson extends BayesianAbstractTestClass {
     // Bayesian is not working on prod-preview environment. Remove that SkipException once this
     // issues is fixed.
     // Issue: https://github.com/redhat-developer/rh-che/issues/524
-    if (cheHost.equals(CHE_PROD_PREVIEW_URL)) {
+    if (isPreview()) {
       throw new SkipException("Skipping bayesian test on prod-preview.");
     }
     setPathToFile(PATH_TO_FILE);

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianPomXml.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/BayesianPomXml.java
@@ -46,7 +46,7 @@ public class BayesianPomXml extends BayesianAbstractTestClass {
     // Bayesian is not working on prod-preview environment. Remove that SkipException once this
     // issues is fixed.
     // Issue: https://github.com/redhat-developer/rh-che/issues/524
-    if (cheHost.equals(CHE_PROD_PREVIEW_URL)) {
+    if (isPreview()) {
       throw new SkipException("Skipping bayesian test on prod-preview.");
     }
     setPathToFile(PATH_TO_FILE);

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/Che7DialogAbout.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/Che7DialogAbout.java
@@ -12,6 +12,7 @@
 package com.redhat.che.functional.tests;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import java.io.IOException;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
@@ -37,7 +38,9 @@ public class Che7DialogAbout {
   private static final Logger LOG = LoggerFactory.getLogger(Che7DialogAbout.class);
 
   private static final String JAVA_MAVEN_DEVFILE_ID = "Java Maven";
+  private static final String LEGACY_SELENIUM_STACK_NAME = "che7";
   private static final String WORKSPACE_NAME = NameGenerator.generate("wksp-", 5);
+  public static final String CHE_PROD_URL = "che.openshift.io";
 
   @Inject private Dashboard dashboard;
   @Inject private TheiaIde theiaIde;
@@ -50,6 +53,10 @@ public class Che7DialogAbout {
   @Inject private ProjectSourcePage projectSourcePage;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
   @Inject private OpenShiftCliCommandExecutor cli;
+
+  @Inject
+  @Named("che.host")
+  String cheHost;
 
   @AfterClass
   public void tearDown() throws Exception {
@@ -129,6 +136,15 @@ public class Che7DialogAbout {
   }
 
   private void selectDevfile(String devfileID) {
-    seleniumWebDriverHelper.waitAndClick(By.xpath("//div[@data-devfile-id='" + devfileID + "']"));
+    if (isProd()) {
+      seleniumWebDriverHelper.waitAndClick(
+          By.xpath("//div[@data-stack-id='" + LEGACY_SELENIUM_STACK_NAME + "']"));
+    } else {
+      seleniumWebDriverHelper.waitAndClick(By.xpath("//div[@data-devfile-id='" + devfileID + "']"));
+    }
+  }
+
+  private boolean isProd() {
+    return CHE_PROD_URL.equals(cheHost);
   }
 }

--- a/functional-tests/src/test/java/com/redhat/che/functional/tests/RhCheAbstractTestClass.java
+++ b/functional-tests/src/test/java/com/redhat/che/functional/tests/RhCheAbstractTestClass.java
@@ -12,6 +12,7 @@
 package com.redhat.che.functional.tests;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -26,10 +27,17 @@ public abstract class RhCheAbstractTestClass {
 
   private static final Logger LOG = LoggerFactory.getLogger(RhCheAbstractTestClass.class);
 
+  public static final String CHE_PROD_PREVIEW_URL = "che.prod-preview.openshift.io";
+  public static final String CHE_PROD_URL = "che.openshift.io";
+
   @Inject private Ide ide;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private CodenvyEditor editor;
+
+  @Inject
+  @Named("che.host")
+  String cheHost;
 
   public void checkWorkspace(TestWorkspace workspace) throws Exception {
     try {
@@ -73,5 +81,13 @@ public abstract class RhCheAbstractTestClass {
 
   public void closeBrowser() {
     ide.close();
+  }
+
+  public boolean isProd() {
+    return CHE_PROD_URL.equals(cheHost);
+  }
+
+  public boolean isPreview() {
+    return CHE_PROD_PREVIEW_URL.equals(cheHost);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Allows us to run tests both on older versions of che and latest Che7 RC2+
Old Che releases were using the stack based approach, Che7 RC2 introduced devfiles which required some changes.

These changes are necessary in order to keep our periodic tests and PR-check on production running.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/che-functional-tests/issues/539

### How have you tested this PR?
manual testing, pr-check