### PR TITLE
rh-che #1488: Adding NPE check in the 'FactoryUrlSetterInterceptor' to avoid failures of workspaces started from devfile

### DIFF
--- a/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/FactoryUrlSetterInterceptor.java
+++ b/plugins/che-plugin-analytics/che-plugin-analytics-wsmaster/src/main/java/com/redhat/che/plugin/analytics/wsmaster/FactoryUrlSetterInterceptor.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
+import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 
 /**
  * This interceptor must be bound for the method {@link
@@ -32,11 +33,14 @@ public class FactoryUrlSetterInterceptor implements MethodInterceptor {
     @SuppressWarnings("unchecked")
     final Map<String, String> parameters = (Map<String, String>) args[0];
     FactoryDto factory = (FactoryDto) invocation.proceed();
-    Map<String, String> attributes = factory.getWorkspace().getAttributes();
-    parameters.forEach(
-        (k, v) -> {
-          attributes.put("factory.parameter." + k, v);
-        });
+    WorkspaceConfigDto workspace = factory.getWorkspace();
+    if (workspace != null) {
+      Map<String, String> attributes = workspace.getAttributes();
+      parameters.forEach(
+          (k, v) -> {
+            attributes.put("factory.parameter." + k, v);
+          });
+    }
     return factory;
   }
 }


### PR DESCRIPTION

### What does this PR do?
Adding NPE check in the 'FactoryUrlSetterInterceptor' to avoid failures of workspaces started from devfile

It appeared to be that in the recent Che versions if factory is started from devfile `factory.getWorkspace()` method would return null. 

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1488

### How have you tested this PR?
CI PR / Check