### PR TITLE
[E2E] Set precise version of tests.

### DIFF
--- a/dockerfiles/e2e-saas/Dockerfile
+++ b/dockerfiles/e2e-saas/Dockerfile
@@ -4,7 +4,7 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM docker.io/eclipse/che-e2e
+FROM docker.io/eclipse/che-e2e:7.0.0-rc-3.0
 
 ENV LANG=en_US.utf8 \
     DISPLAY=:99 \


### PR DESCRIPTION
### What does this PR do?
Set precise version of upstream tests that RH-Che tests are depending on. Test should be broken without setting this version when rc-4 is released. 