### PR TITLE
rh-che #1478: Changing contact support link to upstream Che Mattermost

### DIFF
--- a/plugins/fabric8-end2end-flow/src/main/resources/end2end/files/RhCheKeycloak.js
+++ b/plugins/fabric8-end2end-flow/src/main/resources/end2end/files/RhCheKeycloak.js
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-const osio_msg_relogin_or_contact_support = "<br>You may want to <a href='' onclick='return osioProvisioningLogout()'>use a different account</a><br>or <a href='https://chat.openshift.io/developers/channels/town-square'>contact support</a>.";
+const osio_msg_relogin_or_contact_support = "<br>You may want to <a href='' onclick='return osioProvisioningLogout()'>use a different account</a><br>or <a href='https://mattermost.eclipse.org/eclipse/channels/eclipse-che'>contact support</a>.";
 const osio_msg_provisioning = "Creating your <strong>OpenShift</strong> account";
 const osio_msg_linking_account = "Linking your <strong>OpenShift</strong> account";
 const osio_msg_setting_up_namespaces = "Setting up your <strong>OpenShift.io</strong> environment";


### PR DESCRIPTION
### What does this PR do?
Changing contact support link to upstream Che Mattermost  - https://mattermost.eclipse.org/eclipse/channels/eclipse-che

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1478

### How have you tested this PR?
Not tested