### PR TITLE
[E2E] Removing bail as removing of workspace not working.

### DIFF
--- a/e2e-saas/mocha.opts
+++ b/e2e-saas/mocha.opts
@@ -1,5 +1,4 @@
 --timeout 120000
 --reporter 'node_modules/e2e/dist/driver/CheReporter.js'
 -u tdd
---bail
 --spec ./dist/tests/HappyPath.spec.js


### PR DESCRIPTION
### What does this PR do?
The workspace should be stopped and removed even if tests fails in a `--bail` mode. But workspace is not removed and remains there. As a quick fix for that, the `--bail` option would be disabled.
Issue for fixing the problem: https://github.com/redhat-developer/rh-che/issues/1605

