### PR TITLE
[E2E] Add Vert.x test to production

### DIFF
--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -163,6 +163,7 @@ else
         -e USERNAME=$USERNAME \
         -e PASSWORD=$PASSWORD \
         -e URL=https://$HOST_URL \
+        -e TEST_SUITE=test-all \
         --shm-size=256m \
       quay.io/openshiftio/rhchestage-rh-che-e2e-tests:$TAG
       RESULT=$?


### PR DESCRIPTION
### What does this PR do?
According to test results from prod-preview and flaky test suite running on production, it seems that Java Vert.x test is stable and can be added to production test suite.
