### PR TITLE
Fix tests for 7.2.0

### DIFF
--- a/e2e-saas/tests/JavaMaven.spec.ts
+++ b/e2e-saas/tests/JavaMaven.spec.ts
@@ -70,6 +70,56 @@ suite('RhChe E2E Java Maven test', async () => {
 
     });
 
+    suite('Validation of workspace build and run', async () => {
+
+        // workaround for pop-up not shown  https://github.com/eclipse/che/issues/14724 remove all tests once it is fixed
+        test('Workaround for pop-up not shown', async () => {
+            let taskName: string = 'che: maven build';
+            let tasksFile: string = 'tasks.json';
+            await topMenu.selectOption('Terminal', 'Configure Tasks...');
+            await quickOpenContainer.clickOnContainerItem(taskName);
+            await editor.waitEditorOpened(tasksFile);
+            await editor.moveCursorToLineAndChar(tasksFile, 6, 42);
+            await editor.performKeyCombination(tasksFile, ' > ${CHE_PROJECTS_ROOT}/' + sampleName + '/output.txt');
+
+            await editor.moveCursorToLineAndChar(tasksFile, 15, 42);
+            await editor.performKeyCombination(tasksFile, ' > ${CHE_PROJECTS_ROOT}/' + sampleName + '/output.txt');
+
+            await editor.performKeyCombination(tasksFile, Key.chord(Key.CONTROL, 's'));
+            await editor.waitTabWithSavedStatus(tasksFile);
+        });
+
+        test('Build application', async () => {
+            let taskName: string = 'che: maven build';
+            await runTask(taskName);
+            await quickOpenContainer.clickOnContainerItem('Continue without scanning the task output');
+
+            // replace next two lines by commented line when pop-up issue is fixed
+            // await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 30000);
+            await projectTree.expandPathAndOpenFileInAssociatedWorkspace(sampleName, 'output.txt');
+            await editor.followAndWaitForText('output.txt', '[INFO] BUILD SUCCESS', 220000, 5000);
+        });
+
+        test('Close the terminal tasks', async () => {
+            await terminal.closeTerminalTab('maven build');
+        });
+
+        test('Run application', async () => {
+            let taskName: string = 'che: maven build and run';
+            await runTask(taskName);
+            await quickOpenContainer.clickOnContainerItem('Continue without scanning the task output');
+
+            // replace next two lines by commented line when pop-up issue is fixed
+            // await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 30000);
+            await projectTree.expandPathAndOpenFileInAssociatedWorkspace(sampleName, 'output.txt');
+            await editor.followAndWaitForText('output.txt', '[INFO] BUILD SUCCESS', 220000, 5000);
+        });
+
+        test('Close the terminal tasks', async () => {
+            await terminal.closeTerminalTab('maven build and run');
+        });
+    });
+
     suite('Language server validation', async () => {
         test('Expand project and open file in editor', async () => {
             await projectTree.expandPathAndOpenFileInAssociatedWorkspace(fileFolderPath, tabTitle);
@@ -77,7 +127,8 @@ suite('RhChe E2E Java Maven test', async () => {
         });
 
         test('Java LS initialization', async () => {
-            await ide.checkLsInitializationStart('Starting Java Language Server');
+            // await ide.checkLsInitializationStart('Starting Java Language Server');
+            await ide.waitStatusBarContains('Starting Java Language Server', 20000);
             await ide.waitStatusBarTextAbsence('Starting Java Language Server', 1800000);
             await ide.waitStatusBarTextAbsence('Building workspace', 360000);
         });
@@ -113,28 +164,6 @@ suite('RhChe E2E Java Maven test', async () => {
             await editor.waitEditorAvailable(codeNavigationClassName);
         });
 
-    });
-
-    suite('Validation of workspace build and run', async () => {
-        test('Build application', async () => {
-            let taskName: string = 'che: maven build';
-            await runTask(taskName);
-            await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 30000);
-        });
-
-        test('Close the terminal tasks', async () => {
-            await terminal.closeTerminalTab('maven build');
-        });
-
-        test('Run application', async () => {
-            let taskName: string = 'che: maven build and run';
-            await runTask(taskName);
-            await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 30000);
-        });
-
-        test('Close the terminal tasks', async () => {
-            await terminal.closeTerminalTab('maven build and run');
-        });
     });
 
     suite('Stop and remove workspace', async () => {


### PR DESCRIPTION
### What does this PR do?
Removing refreshing of browser after failed LS initialization. 
Add workarounds for https://github.com/eclipse/che/issues/14724.

### How have you tested this PR?
Localy against http://rhche-prcheck-1626.devtools-dev.ext.devshift.net where Rh-Che 7.2.0 is deployed. 