### PR TITLE
Reduce logging from rsync when transferring images in CI

### DIFF
--- a/.ci/cico_do_docker_build_tag_push.sh
+++ b/.ci/cico_do_docker_build_tag_push.sh
@@ -52,7 +52,7 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
     fi
   fi
 
-  docker build -t ${DOCKER_IMAGE_URL}:${TAG} -f $DIR/${DOCKERFILE} .
+  docker build -t ${DOCKER_IMAGE_URL}:${TAG} -f $DIR/${DOCKERFILE} . | cat
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'
     exit 2
@@ -69,17 +69,17 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
   fi
   
   if [ "${USE_CHE_LATEST_SNAPSHOT}" == "true" ]; then
-    docker push ${DOCKER_IMAGE_URL}:${DOCKER_IMAGE_TAG_WITH_SHORTHASHES}
-    docker push ${DOCKER_IMAGE_URL}:${DOCKER_IMAGE_TAG}
+    docker push ${DOCKER_IMAGE_URL}:${DOCKER_IMAGE_TAG_WITH_SHORTHASHES} | cat
+    docker push ${DOCKER_IMAGE_URL}:${DOCKER_IMAGE_TAG} | cat
   else
     if [ "$DeveloperBuild" != "true" ]; then
-      docker push ${DOCKER_IMAGE_URL}:${NIGHTLY}
-      docker push ${DOCKER_IMAGE_URL}:${TAG}
+      docker push ${DOCKER_IMAGE_URL}:${NIGHTLY} | cat
+      docker push ${DOCKER_IMAGE_URL}:${TAG} | cat
     fi
   fi
 
   if [ "${NIGHTLY}" != "*-no-dashboard" ] && [ "$PR_CHECK_BUILD" != "true" ]; then
-      docker build -t ${KEYCLOAK_DOCKER_IMAGE_URL}:${TAG} $ADDONS/rhche-prerequisites/keycloak-configurator
+      docker build -t ${KEYCLOAK_DOCKER_IMAGE_URL}:${TAG} $ADDONS/rhche-prerequisites/keycloak-configurator | cat
 
       if [ $? -ne 0 ]; then
         echo 'Docker Build Failed'
@@ -92,8 +92,8 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
       dockerTags="${dockerTags} ${REGISTRY}/${NAMESPACE}/${KEYCLOAK_STANDALONE_CONFIGURATOR_IMAGE}:${NIGHTLY} ${REGISTRY}/${NAMESPACE}/${KEYCLOAK_STANDALONE_CONFIGURATOR_IMAGE}:${TAG}"
 
       if [ "$DeveloperBuild" != "true" ]; then
-          docker push ${KEYCLOAK_DOCKER_IMAGE_URL}:${NIGHTLY}
-          docker push ${KEYCLOAK_DOCKER_IMAGE_URL}:${TAG}
+          docker push ${KEYCLOAK_DOCKER_IMAGE_URL}:${NIGHTLY} | cat
+          docker push ${KEYCLOAK_DOCKER_IMAGE_URL}:${TAG} | cat
       fi
   fi
 done
@@ -107,7 +107,7 @@ fi
 echo "!"
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 echo "!"
-echo "! Created / tagged the following eclipse Che images:"
+echo "! Created / tagged the following Eclipse Che images:"
 echo "!     ${dockerTags}"
 echo "! in the ${dockerEnv}"
 echo "!"

--- a/.ci/functional_tests_utils.sh
+++ b/.ci/functional_tests_utils.sh
@@ -113,7 +113,7 @@ function archiveArtifacts() {
   cp -R ./logs/artifacts/screenshots/ ./rhche/${JOB_NAME}/${BUILD_NUMBER}/
   cp -R ./logs/artifacts/failsafe-reports/ ./rhche/${JOB_NAME}/${BUILD_NUMBER}/
   cp ./events_report.txt ./rhche/${JOB_NAME}/${BUILD_NUMBER}/
-  rsync --password-file=./artifacts.key -PHva --relative ./rhche/${JOB_NAME}/${BUILD_NUMBER} devtools@artifacts.ci.centos.org::devtools/
+  rsync --password-file=./artifacts.key -Hva --partial --relative ./rhche/${JOB_NAME}/${BUILD_NUMBER} devtools@artifacts.ci.centos.org::devtools/
 }
 
 function getVersionFromPom() {

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -102,7 +102,7 @@ if [[ "$PR_CHECK_BUILD" == "true" ]]; then
   rhche_image="quay.io/openshiftio/rhchestage-rh-che-e2e-tests:${version}"
 
   #reuse image if exists or build new image for test
-  if docker pull $rhche_image; then
+  if docker pull $rhche_image | cat; then
     echo "RH-Che test image with tag ${version} found on docker. Reusing image."
 	else
     echo "Could not found RH-Che tests image with tag ${version}."


### PR DESCRIPTION
### What does this PR do?
Removes progress bars from rsync step in CI builds, since some failures can fill 1/3rd of the log with progress that's formatted for a tty.
