### PR TITLE
Switched che_version extraction from static master to the source branch

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -19,7 +19,7 @@ eval "$(./env-toolkit load -f jenkins-env.json -r \
         ^KEYCLOAK \
         ^BUILD_NUMBER$ \
         ^JOB_NAME$ \
-        ^ghprbPullId$ \
+        ^ghprb \
         ^RH_CHE)"
 
 source ./config
@@ -37,7 +37,7 @@ echo "Installing all dependencies lasted $instal_dep_duration seconds."
 
 export PROJECT_NAMESPACE=prcheck-${RH_PULL_REQUEST_ID}
 export DOCKER_IMAGE_TAG="${RH_TAG_DIST_SUFFIX}"-"${RH_PULL_REQUEST_ID}"
-CHE_VERSION=$(curl -s https://raw.githubusercontent.com/redhat-developer/rh-che/master/pom.xml | xq -r '.project.parent.version')
+CHE_VERSION=$(getVersionFromPom)
 export CHE_VERSION
 
 echo "Running ${JOB_NAME} PR: #${RH_PULL_REQUEST_ID}, build number #${BUILD_NUMBER} for che-version:${CHE_VERSION}"


### PR DESCRIPTION
### What does this PR do?
Changed logic for extracting Che version to use the source branch of the PR instead of the master when running prcheck script

### What issues does this PR fix or reference?
hotfix - deploying incorrect version of registries for prcheck

### How have you tested this PR?
manual testing