### PR TITLE
Replace jgroups 4.1.0 with 4.1.8

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -24,6 +24,7 @@
     <packaging>war</packaging>
     <name>Fabric8 IDE :: Assemblies :: Workspace Master</name>
     <properties>
+        <org.jgroups.version>4.1.8.Final</org.jgroups.version>
         <original-project-basedir>assembly/${original-project-name}</original-project-basedir>
         <original-project-name>assembly-wsmaster-war</original-project-name>
     </properties>
@@ -104,6 +105,11 @@
             <artifactId>che-multiuser-personal-account</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jgroups</groupId>
+            <artifactId>jgroups</artifactId>
+            <version>${org.jgroups.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -136,7 +142,7 @@
                         </overlay>
                     </overlays>
                     <packagingExcludes>WEB-INF/lib/che-core-ide-stacks-${che.version}.jar,
-                        WEB-INF/classes/che-in-che.json</packagingExcludes>
+                        WEB-INF/classes/che-in-che.json,WEB-INF/lib/jgroups-4.1.0.Final.jar</packagingExcludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -155,6 +161,7 @@
                                 <dep>com.redhat.che:fabric8-ide-stacks</dep>
                                 <dep>org.eclipse.che.multiuser:che-multiuser-keycloak-server</dep>
                                 <dep>org.eclipse.che.multiuser:che-multiuser-personal-account</dep>
+                                <dep>org.jgroups:jgroups</dep>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This reverts commit 8c800632c058547e0411beee976d9063d425b6ad.

### What does this PR do?
Replace jgroups 4.1.0 with 4.1.8

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15231

### How have you tested this PR?
N/A