### PR TITLE
Fixed the attachment colors, they work based on AVG startup times now

### DIFF
--- a/.ci/workspace-startup/start-workspace-reporter/src/main/java/com/redhat/che/start_workspace_reporter/model/ZabbixHistoryMetricsEntry.java
+++ b/.ci/workspace-startup/start-workspace-reporter/src/main/java/com/redhat/che/start_workspace_reporter/model/ZabbixHistoryMetricsEntry.java
@@ -60,10 +60,10 @@ public class ZabbixHistoryMetricsEntry implements Comparable<ZabbixHistoryMetric
 
   @Override
   public int compareTo(ZabbixHistoryMetricsEntry o) {
-    if (Integer.valueOf(o.getClock()) > Integer.valueOf(this.getClock())) return -1;
-    if (Integer.valueOf(o.getClock()) < Integer.valueOf(this.getClock())) return 1;
-    if (Integer.valueOf(o.getNs()) > Integer.valueOf(this.getNs())) return -1;
-    if (Integer.valueOf(o.getNs()) < Integer.valueOf(this.getNs())) return 1;
+    if (Integer.parseInt(o.getClock()) > Integer.parseInt(this.getClock())) return -1;
+    if (Integer.parseInt(o.getClock()) < Integer.parseInt(this.getClock())) return 1;
+    if (Integer.parseInt(o.getNs()) > Integer.parseInt(this.getNs())) return -1;
+    if (Integer.parseInt(o.getNs()) < Integer.parseInt(this.getNs())) return 1;
     return 0;
   }
 }

--- a/.ci/workspace-startup/start-workspace-reporter/src/main/java/com/redhat/che/start_workspace_reporter/util/Constants.java
+++ b/.ci/workspace-startup/start-workspace-reporter/src/main/java/com/redhat/che/start_workspace_reporter/util/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
   public static final String SLACK_SUCCESS_COLOR = "#2EB886";
   public static final String SLACK_UNSTABLE_COLOR = "#FFAA00";
   public static final String SLACK_BROKEN_COLOR = "#FF0000";
+  public static final String SLACK_NO_DATA_COLOR = "#333333";
   public static final float SLACK_BROKEN_PERCENTAGE = 5f; // above value
   public static final float SLACK_UNSTABLE_PERCENTAGE = 1f; // above value
   public static final String SUFFIX_AVG = "_AVG";

--- a/.ci/workspace-startup/start-workspace-reporter/src/main/resources/slack_post_template.json
+++ b/.ci/workspace-startup/start-workspace-reporter/src/main/resources/slack_post_template.json
@@ -6,7 +6,7 @@
     {
       "fallback": "Required plain-text summary of the attachment.",
       "color": "STARTER_US_EAST_1A_COLOR",
-      "mrkdwn_in": ["fields"],
+      "mrkdwn_in": ["fields", "text"],
       "fields": [
         {
           "title": "Cluster 1a start",
@@ -23,7 +23,7 @@
     {
       "fallback": "Required plain-text summary of the attachment.",
       "color": "STARTER_US_EAST_1B_COLOR",
-      "mrkdwn_in": ["fields"],
+      "mrkdwn_in": ["fields", "text"],
       "fields": [
         {
           "title": "Cluster 1b start",
@@ -40,7 +40,7 @@
     {
       "fallback": "Required plain-text summary of the attachment.",
       "color": "STARTER_US_EAST_2_COLOR",
-      "mrkdwn_in": ["fields"],
+      "mrkdwn_in": ["fields", "text"],
       "fields": [
         {
           "title": "Cluster 2 start",
@@ -57,7 +57,7 @@
     {
       "fallback": "Required plain-text summary of the attachment.",
       "color": "STARTER_US_EAST_2A_COLOR",
-      "mrkdwn_in": ["fields"],
+      "mrkdwn_in": ["fields", "text"],
       "fields": [
         {
           "title": "Cluster 2a start",
@@ -74,7 +74,7 @@
     {
       "fallback": "Required plain-text summary of the attachment.",
       "color": "STARTER_US_EAST_2A_PREVIEW_COLOR",
-      "mrkdwn_in": ["fields"],
+      "mrkdwn_in": ["fields", "text"],
       "fields": [
         {
           "title": "Cluster 2a preview start",


### PR DESCRIPTION
### What does this PR do?
This PR changes the logic for the workspace-startup-reporter regarding how are the thresholds calculated, switching over from the percent change over to fixed startup time values

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1680

### How have you tested this PR?
Manual testing, sending into private slack channel.