### PR TITLE
Add getMavenVersion

### DIFF
--- a/.ci/cico_build_func_dep.sh
+++ b/.ci/cico_build_func_dep.sh
@@ -62,6 +62,7 @@ source .ci/functional_tests_utils.sh
 
 DOCKERFILE="e2e-saas/"
 DOCKER_IMAGE="rh-che-e2e-tests"
+getMavenVersion
 TAG=$(getVersionFromPom)
 DOCKER_IMAGE_URL="${REGISTRY}/openshiftio/${NAMESPACE}-${DOCKER_IMAGE}"
 

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -146,6 +146,7 @@ else
   
   #PRODUCTION
   if [[ "$HOST_URL" == "che.openshift.io" ]]; then
+    getMavenVersion
     TAG=$(getVersionFromProd)
     echo "Running test with user $USERNAME against prod environment with version $TAG."
 
@@ -179,6 +180,7 @@ else
     
   #PROD-PREVIEW
   else
+    getMavenVersion
     TAG=$(getVersionFromProdPreview)
     echo "Running test with user $USERNAME against prod-preview environment with version $TAG."
   


### PR DESCRIPTION
### What does this PR do?
Add `getMavenVersion` before every getVersion<sth> command to easily debug failures. It would be especially useful in periodic test debugging. 