### PR TITLE
Revert replacing jgroups 4.1.0 with 4.1.8 (Falling back to upstream 4.1.9)

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -24,7 +24,6 @@
     <packaging>war</packaging>
     <name>Fabric8 IDE :: Assemblies :: Workspace Master</name>
     <properties>
-        <org.jgroups.version>4.1.8.Final</org.jgroups.version>
         <original-project-basedir>assembly/${original-project-name}</original-project-basedir>
         <original-project-name>assembly-wsmaster-war</original-project-name>
     </properties>
@@ -109,11 +108,6 @@
             <artifactId>che-multiuser-personal-account</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jgroups</groupId>
-            <artifactId>jgroups</artifactId>
-            <version>${org.jgroups.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -146,7 +140,7 @@
                         </overlay>
                     </overlays>
                     <packagingExcludes>WEB-INF/lib/che-core-ide-stacks-${che.version}.jar,
-                        WEB-INF/classes/che-in-che.json,WEB-INF/lib/jgroups-4.1.0.Final.jar</packagingExcludes>
+                        WEB-INF/classes/che-in-che.json</packagingExcludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -165,7 +159,6 @@
                                 <dep>com.redhat.che:fabric8-ide-stacks</dep>
                                 <dep>org.eclipse.che.multiuser:che-multiuser-keycloak-server</dep>
                                 <dep>org.eclipse.che.multiuser:che-multiuser-personal-account</dep>
-                                <dep>org.jgroups:jgroups</dep>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This reverts commit 8ddcf82d55fa545a73ee07a0ede59f394f170b6e
jgroups should have been fixed in the 7.7.0 with 4.1.9 release

### What does this PR do?
This reverts commit 8ddcf82d55fa545a73ee07a0ede59f394f170b6e
Which was used as a temp workaround

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15625

### How have you tested this PR?
PR check CI