### PR TITLE
Readme change, ghprbTriggerAuthor removal

### DIFF
--- a/.ci/cico_rhche_prcheck.sh
+++ b/.ci/cico_rhche_prcheck.sh
@@ -19,7 +19,7 @@ eval "$(./env-toolkit load -f jenkins-env.json -r \
         ^KEYCLOAK \
         ^BUILD_NUMBER$ \
         ^JOB_NAME$ \
-        ^ghprb \
+        ^ghprbPullId \
         ^RH_CHE \
         ^GIT_COMMIT)"
         

--- a/e2e-saas/README.md
+++ b/e2e-saas/README.md
@@ -64,4 +64,4 @@ Java Vert.x test flow is following:
 - Stop workspace
 - Delete workspace
 
-Java Vert.x tests is saved in upstream and is only reused on Hosted Che side. Test for Java Maven should be moved to upstream too. 
+Java Vert.x and Java Maven tests are saved in upstream and are only reused on Hosted Che side. Login test is used from downstream repo.


### PR DESCRIPTION
### What does this PR do?
Small change to README.
Small change to prcheck script - now not all ghprb variables will be exported. There was a `ghprbTriggerAuthor` exported and for me it was `Kateřina Foniok`. It was not able to parse my name and I was not able to find out what else should I change on github account to get it working correctly.
