### PR TITLE
[Route tests] Add events to the log of a job.

### DIFF
--- a/functional-tests/devscripts/route_tests.sh
+++ b/functional-tests/devscripts/route_tests.sh
@@ -159,6 +159,9 @@ if ! $hard_failed; then
 	done
 fi
 
+echo "--------------- EVENTS -----------------"
+oc get events
+
 if $SEND_TO_ZABBIX; then
     echo "--------------- Send time to Zabbix -----------------"
     ZABBIX_HOST=""


### PR DESCRIPTION
### What does this PR do?
Add `oc get events` output to route tests. That will ease investigation if route tests fail. 
