### PR TITLE
Fix compatibility check job: fix setting Che version from upstream

### DIFF
--- a/.ci/cico_compatibility_build_check.sh
+++ b/.ci/cico_compatibility_build_check.sh
@@ -15,6 +15,6 @@ git rebase origin/master || (echo "ERROR: Rebasing branch 'upstream' on top of '
 
 CHE_VERSION=$(curl -s https://raw.githubusercontent.com/eclipse/che/master/pom.xml | grep "^    <version>.*</version>$" | awk -F'[><]' '{print $3}')
 echo ">>> change upstream version to: $CHE_VERSION"
-scl enable rh-maven33 'mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion=[$CHE_VERSION] -Dmaven.repo.local=${WORKSPACE}/.repository -U'
-scl enable rh-maven33 'mvn versions:update-property -Dproperty=che.version -DnewVersion=[$CHE_VERSION] -DallowDowngrade=true -DgenerateBackupPoms=false -Dmaven.repo.local=${WORKSPACE}/.repository'
-scl enable rh-maven33 'mvn clean install -Dmaven.repo.local=${WORKSPACE}/.repository'
+scl enable rh-maven33 'mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion=[$CHE_VERSION]'
+scl enable rh-maven33 'mvn versions:update-property -Dproperty=che.version -DnewVersion=[$CHE_VERSION] -DallowDowngrade=true -DgenerateBackupPoms=false'
+scl enable rh-maven33 'mvn clean install'


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### What does this PR do?
Fix compatibility check job: fix setting Che versions from upstream 
was error in 
`mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion=[$CHE_VERSION] -Dmaven.repo.local=${WORKSPACE}/.repository -U`


```
[ERROR] Could not create local repository at /.repository -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```

### What issues does this PR fix or reference?


### How have you tested this PR?
