### PR TITLE
che #16224 Updating Hosted Che to the latest 7.9.1 upstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.9.0</version>
+        <version>7.9.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
@@ -31,7 +31,7 @@
         <module>functional-tests</module>
     </modules>
     <properties>
-        <che.version>7.9.0</che.version>
+        <che.version>7.9.1</che.version>
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Updating Hosted Che to the latest 7.9.1 upstream version

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16224

### How have you tested this PR?
PR check CI against dev-cluster