### PR TITLE
Fixing misconfigured mocha-pr-check.opts suite

### DIFF
--- a/e2e-saas/mocha-pr-check.opts
+++ b/e2e-saas/mocha-pr-check.opts
@@ -1,5 +1,5 @@
 --timeout 120000
---reporter 'node_modules/e2e/dist/driver/CheReporter.js'
+--reporter './dist/utils/RhCheReporter.js'
 -u tdd
 --spec ./dist/tests/login/Login.spec
 --spec ./dist/tests/devfiles/JavaMaven.spec


### PR DESCRIPTION
### What does this PR do?
Hotfix for rh-che prcheck test logic.
We were using an incorrect Reporter class which was causing issues with API calls because of different approach to getting ActiveToken of a user account.
This switches the suite to use our downstream implementation.

### What issues does this PR fix or reference?
hotfix

### How have you tested this PR?
manually against deployment on de-cluster