### PR TITLE
che-15261: Update with upstream che

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -84,6 +84,9 @@
                                 <include>_app/loader.js</include>
                                 <include>_app/loader.css</include>
                                 <include>_app/loader.html</include>
+                                <include>_app/keycloackLoader.js</include>
+                                <include>_app/oauthLoader.js</include>
+                                <include>_app/oauth.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>


### PR DESCRIPTION
### What does this PR do?
Add missing files to `assembly-ide-war`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/16488

### How have you tested this PR?
Built the project and checked that the `fabric8-ide-assembly-ide-war-1.0.0-SNAPSHOT.war` includes missing files