### PR TITLE
Add video recording to tests

### DIFF
--- a/.ci/cico_build_deploy_test_rhche.sh
+++ b/.ci/cico_build_deploy_test_rhche.sh
@@ -48,7 +48,7 @@ echo "Build, tag and push lasted $build_tag_push_duration seconds."
 # Deploy rh-che image
 echo "Deploying image with tag ${DOCKER_IMAGE_TAG} from ${DOCKER_IMAGE_URL}"
 
-#create project before deployment script to be able to set policy
+# create project before deployment script to be able to set policy
 if oc project "${PROJECT_NAMESPACE}" > /dev/null 2>&1;
 then
   echo "Switched to project ${PROJECT_NAMESPACE}"

--- a/dockerfiles/e2e-saas/Dockerfile
+++ b/dockerfiles/e2e-saas/Dockerfile
@@ -8,7 +8,6 @@ ARG TAG=latest
 FROM quay.io/eclipse/che-e2e:$TAG
 
 ENV LANG=en_US.utf8 \
-    DISPLAY=:99 \
     FABRIC8_USER_NAME=fabric8
 
 # currently in tmp/e2e

--- a/dockerfiles/e2e-saas/docker-entrypoint.sh
+++ b/dockerfiles/e2e-saas/docker-entrypoint.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+kill_ffmpeg(){
+  echo "In method kill_ffmpeg()"
+  echo "Killing ffmpeg with PID=$ffmpeg_pid"
+  kill -2 "$ffmpeg_pid"
+  return 0
+}
+
 # ------------------------------------------------------------------------------------------
 # ------------------------------- VALIDATE ALL REQUIRED PARAMETERS -------------------------
 # ------------------------------------------------------------------------------------------
@@ -132,10 +139,12 @@ do
 done
 
 echo "Running Xvfb"
-/usr/bin/Xvfb :1 -screen 0 1920x1080x24 +extension RANDR > /dev/null 2>&1 &
 
-x11vnc -display :1.0 > /dev/null 2>&1 &
-export DISPLAY=:1.0
+export DISPLAY=":20"
+export SCREEN="0"
+
+/usr/bin/Xvfb $DISPLAY -screen $SCREEN 1920x1080x24 > /dev/null 2>&1 &
+x11vnc -display $DISPLAY > /dev/null 2>&1 &
 
 # ------------------------------------------------------------------------------------------
 #----------------------------------- RUN TESTS ---------------------------------------------
@@ -165,5 +174,17 @@ fi
 echo "Installing upstream dependency."
 npm --silent i ../../e2e/
 
+# create a folder and record a video
+ffmpeg_path="./report/ffmpeg_report"
+mkdir -p $ffmpeg_path
+nohup ffmpeg -y -video_size 1920x1080 -framerate 24 -f x11grab -i $DISPLAY.$SCREEN $ffmpeg_path/output.mp4 2> $ffmpeg_path/ffmpeg_err.txt > $ffmpeg_path/ffmpeg_std.txt & 
+ffmpeg_pid=$!
+trap kill_ffmpeg 2 15
+
 echo "Running test suite: $TEST_SUITE"
 npm run $TEST_SUITE
+RESULT=$?
+
+kill_ffmpeg
+echo "Exiting docker entrypoint with status $RESULT"
+exit $RESULT

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -97,7 +97,7 @@ if [[ "$PR_CHECK_BUILD" == "true" ]]; then
   #check version in rh-che pom.xml to use correct version of tests.
   getMavenVersion # Checking the maven version for debugging https://github.com/redhat-developer/rh-che/issues/1716
   version=$(getVersionFromPom)
-  if [[ -z "${version}" ]]; then
+  if [[ -z "${version}" || $version = "" ]]; then
     echo "[ERROR]: Could not find version in pom.xml."
     exit 1
   fi
@@ -108,8 +108,10 @@ if [[ "$PR_CHECK_BUILD" == "true" ]]; then
   docker_pull_exit_code=$?
 
   if [[ $docker_pull_exit_code == 0 ]]; then
-    echo "RH-Che test image with tag ${version} found on docker. Reusing image."
-	else
+      echo "Rebuilding test image based on ${version} upstream version."
+      docker build --build-arg TAG=${version} -t e2e_tests dockerfiles/e2e-saas
+      rhche_image=e2e_tests
+  else
     echo "Could not found RH-Che tests image with tag ${version}."
     if [ $(curl -X GET https://quay.io/api/v1/repository/eclipse/che-e2e/tag/${version}/images | jq .status) == null ]; then
       echo "Upstream image with tag ${version} found. Building own RH-Che image based on Che image with ${version} tag."

--- a/functional-tests/devscripts/run_tests.sh
+++ b/functional-tests/devscripts/run_tests.sh
@@ -97,7 +97,7 @@ if [[ "$PR_CHECK_BUILD" == "true" ]]; then
   #check version in rh-che pom.xml to use correct version of tests.
   getMavenVersion # Checking the maven version for debugging https://github.com/redhat-developer/rh-che/issues/1716
   version=$(getVersionFromPom)
-  if [[ -z "${version}" || $version = "" ]]; then
+  if [ -z "${version}" ]; then
     echo "[ERROR]: Could not find version in pom.xml."
     exit 1
   fi


### PR DESCRIPTION
### What does this PR do?
**Adding logic for building a test image.**
Currently, if there is already a test image pushed with the corresponding version, the image is not rebuilt in the PR check flow. Adding logic that will check, if there are some changes made in rh-che/dockerfiles/e2e-saas folder. If so, the test image will not be reused but rebuilt.

**Add video recording to tests.**
In previous versions, there were no videos, but every second the screenshot was taken and a screencast was saved in artifacts. Now, in upstream, they removed that logic and added video recording directly to the docker entrypoint. We need to adapt and to set the same recording in our entrypint.

