### PR TITLE
Pre release suite fix for saas-openshiftio

### DIFF
--- a/.ci/cico_pre_release_tests.sh
+++ b/.ci/cico_pre_release_tests.sh
@@ -20,7 +20,11 @@ ACCOUNT_ENV="prod-preview"
 source .ci/cico_utils.sh
 
 echo "****** Starting prelease tests $(date) ******"
-TEST_URL="${ghprbCommentBody%%"\r\n"*}"
+if [[ $JOB_NAME == *"saas-openshiftio"* ]]; then
+    TEST_URL="https://che.prod-preview.openshift.io";  
+else
+    TEST_URL="${ghprbCommentBody%%"\r\n"*}";
+fi
 
 installDocker
 installJQ


### PR DESCRIPTION
### What does this PR do?
Add switch of TEST_URL for saas-openshiftio. In the job running in `saas-openshiftio` repo it will not be possible to set a URL as tests are always expected to run against https://che.prod-preview.openshift.io.

