### PR TITLE
Updating Hosted Che to the latest '7.18.1' upstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.18.0</version>
+        <version>7.18.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
@@ -30,7 +30,7 @@
         <module>assembly</module>
     </modules>
     <properties>
-        <che.version>7.18.0</che.version>
+        <che.version>7.18.1</che.version>
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>


### PR DESCRIPTION
### What does this PR do?
Updating Hosted Che to the latest '7.18.1' upstream version

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17771

### How have you tested this PR?
PR check