### PR TITLE
che #17590 Using the correct dashboard version during the Hosted Che image builds

### DIFF
--- a/.ci/cico_do_docker_build_tag_push.sh
+++ b/.ci/cico_do_docker_build_tag_push.sh
@@ -51,8 +51,9 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
       exit 1
     fi
   fi
-
-  docker build -t ${DOCKER_IMAGE_URL}:${TAG} -f $DIR/${DOCKERFILE} . | cat
+  
+  echo "Upstream Eclipse Che version: ${CHE_VERSION}"
+  docker build -t ${DOCKER_IMAGE_URL}:${TAG} --build-arg CHE_DASHBOARD_VERSION=${CHE_VERSION} --build-arg CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION} -f $DIR/${DOCKERFILE} . | cat
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'
     exit 2


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Using the correct dashboard version during the Hosted Che image builds

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17590

### How have you tested this PR?
PR check CI