### PR TITLE
che #17590 Getting the valid upstream CHE_VERSION for the master build

### DIFF
--- a/.ci/cico_build.sh
+++ b/.ci/cico_build.sh
@@ -40,10 +40,14 @@ if [[ "$DeveloperBuild" != "true" && "$PR_CHECK_BUILD" != "true" && "$USE_CHE_LA
 
   yum -y install rh-nodejs8
 
-  # Installing the latest version of Docker
   source .ci/cico_utils.sh
-  installDocker
 
+  # Getting the upstream Eclipse Che version
+  CHE_VERSION=$(getVersionFromPom)
+  export CHE_VERSION
+
+  # Installing the latest version of Docker
+  installDocker
   BuildUser="chebuilder"
 
   useradd ${BuildUser}


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
 Getting the valid upstream CHE_VERSION for the master build

### What issues does this PR fix or reference?
fixup for https://github.com/eclipse/che/issues/17590

### How have you tested this PR?
PR check