### PR TITLE
Updating Hosted Che to the 7.19.0 upstream version. Adding GatewayRouterProvisioner to constructor

### DIFF
--- a/.ci/cico_do_docker_build_tag_push.sh
+++ b/.ci/cico_do_docker_build_tag_push.sh
@@ -53,7 +53,12 @@ for distribution in `echo ${ABSOLUTE_PATH}/../${distPath}`; do
   fi
   
   echo "Upstream Eclipse Che version: ${CHE_VERSION}"
-  docker build -t ${DOCKER_IMAGE_URL}:${TAG} --build-arg CHE_DASHBOARD_VERSION=${CHE_VERSION} --build-arg CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION} -f $DIR/${DOCKERFILE} . | cat
+  if [[ "$CHE_VERSION" == *"SNAPSHOT"  ]]; then
+    docker build -t ${DOCKER_IMAGE_URL}:${TAG} --build-arg CHE_DASHBOARD_VERSION="next" --build-arg CHE_WORKSPACE_LOADER_VERSION="next" -f $DIR/${DOCKERFILE} . | cat
+  else 
+    docker build -t ${DOCKER_IMAGE_URL}:${TAG} --build-arg CHE_DASHBOARD_VERSION=${CHE_VERSION} --build-arg CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION} -f $DIR/${DOCKERFILE} . | cat
+  fi
+
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'
     exit 2

--- a/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/RhCheInfraEnvironmentProvisioner.java
+++ b/plugins/fabric8-multi-tenant-manager/src/main/java/com/redhat/che/multitenant/RhCheInfraEnvironmentProvisioner.java
@@ -34,6 +34,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.Workspa
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStoragePodInterceptor;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
@@ -101,6 +102,7 @@ public class RhCheInfraEnvironmentProvisioner extends OpenShiftEnvironmentProvis
       GitConfigProvisioner gitConfigProvisioner,
       OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner,
       VcsSslCertificateProvisioner vcsSslCertificateProvisioner,
+      GatewayRouterProvisioner gatewayRouterProvisioner,
       @Named("che.infra.kubernetes.trust_certs") boolean trustCerts,
       @Named("che.fabric8.wsagent_routing_timeout") String wsAgentRoutingTimeout) {
     super(
@@ -124,7 +126,8 @@ public class RhCheInfraEnvironmentProvisioner extends OpenShiftEnvironmentProvis
         sshKeysProvisioner,
         gitConfigProvisioner,
         previewUrlEndpointsProvisioner,
-        vcsSslCertificateProvisioner);
+        vcsSslCertificateProvisioner,
+        gatewayRouterProvisioner);
 
     this.openshiftUserTokenProvider = openshiftUserTokenProvider;
     this.tenantDataProvider = tenantDataProvider;

--- a/plugins/fabric8-multi-tenant-manager/src/test/java/com/redhat/che/multitenant/RhCheInfraEnvironmentProvisionerTest.java
+++ b/plugins/fabric8-multi-tenant-manager/src/test/java/com/redhat/che/multitenant/RhCheInfraEnvironmentProvisionerTest.java
@@ -45,6 +45,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.Workspa
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStoragePodInterceptor;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
@@ -104,6 +105,7 @@ public class RhCheInfraEnvironmentProvisionerTest {
   @Mock private OpenShiftEnvironment openShiftEnvironment;
   @Mock private ServiceAccountProvisioner serviceAccountProvisioner;
   @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
+  @Mock private GatewayRouterProvisioner gatewayRouterProvisioner;
 
   private List<EnvVar> con1EnvVars;
   private List<EnvVar> con2EnvVars;
@@ -143,6 +145,7 @@ public class RhCheInfraEnvironmentProvisionerTest {
             gitConfigProvisioner,
             openshiftPreviewUrlExposer,
             vcsSslCertificateProvisioner,
+            gatewayRouterProvisioner,
             false,
             WSAGENT_ROUTER_TIMEOUT);
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.18.2</version>
+        <version>7.19.0-SNAPSHOT</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
@@ -30,7 +30,7 @@
         <module>assembly</module>
     </modules>
     <properties>
-        <che.version>7.18.2</che.version>
+        <che.version>7.19.0-SNAPSHOT</che.version>
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-parent</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.19.0-SNAPSHOT</version>
+        <version>7.19.0</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
@@ -30,7 +30,7 @@
         <module>assembly</module>
     </modules>
     <properties>
-        <che.version>7.19.0-SNAPSHOT</che.version>
+        <che.version>7.19.0</che.version>
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>


### PR DESCRIPTION
Signed-off-by: Tom George <tg82490@gmail.com>

### What does this PR do?

Fixes the failed PR check build https://ci.centos.org/view/Devtools/job/devtools-rh-che-rh-che-prcheck-dev.rdu2c.fabric8.io/2884/console