### PR TITLE
che #18770 Updating Hosted Che to the latest '7.24.1' upstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>che-server</artifactId>
         <groupId>org.eclipse.che</groupId>
-        <version>7.24.0</version>
+        <version>7.24.1</version>
     </parent>
     <groupId>com.redhat.che</groupId>
     <artifactId>fabric8-ide-parent</artifactId>
@@ -30,7 +30,7 @@
         <module>assembly</module>
     </modules>
     <properties>
-        <che.version>7.24.0</che.version>
+        <che.version>7.24.1</che.version>
         <keycloak.version>2.5.0.Final</keycloak.version>
         <redhat.che.version>1.0.0-SNAPSHOT</redhat.che.version>
         <rh.che.plugins.version>1.0.0-SNAPSHOT</rh.che.plugins.version>


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Updating Hosted Che to the latest '7.24.1' upstream version

### What issues does this PR fix or reference?
Related issue - https://github.com/eclipse/che/issues/18770

### How have you tested this PR?
PR check CI